### PR TITLE
Wrap all REST endpoints with authz

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -236,6 +236,7 @@ func init() {
 	if err != nil {
 		log.Println(err.Error())
 	}
+	Validator = NewNobodyValidator()
 	Items = items.New(store.NewMemory())
 	TxStore = transaction.New(store.NewMemory())
 	TxStore.Load()

--- a/server/token.go
+++ b/server/token.go
@@ -46,14 +46,22 @@ func AtoRole(s string) Role {
 
 // NewNobodyValidator creates a TokenValidator that for every possible token
 // returns a user named "nobody" with the Admin role.
-func NewNobodyValidator() TokenValidator {
-	return new(nobodyValidator)
-}
+func NewNobodyValidator() TokenValidator { return new(nobodyValidator) }
 
 type nobodyValidator struct{}
 
-func (_ nobodyValidator) TokenValid(token string) (user string, role Role, err error) {
+func (_ nobodyValidator) TokenValid(token string) (string, Role, error) {
 	return "nobody", RoleAdmin, nil
+}
+
+// NewInvalidValidator creates a TokenValidator that for which every token is
+// invalid. That is, it always returns the user "" with the Unknown role.
+func NewInvalidValidator() TokenValidator { return new(invalidValidator) }
+
+type invalidValidator struct{}
+
+func (_ invalidValidator) TokenValid(token string) (string, Role, error) {
+	return "", RoleUnknown, nil
 }
 
 // A ListValidator is backed by a predefined list of users, which are read from r upon creation.

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -72,7 +72,7 @@ func NewTxHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		return
 	}
 	w.Header().Set("Location", "/transaction/"+tx.ID)
-	tx.Creator = "nobody"
+	tx.Creator = ps.ByName("username")
 	// TODO(dbrower): use a limit reader to 1MB(?) for this
 	var cmds [][]string
 	err = json.NewDecoder(r.Body).Decode(&cmds)


### PR DESCRIPTION
Continues the work on issue #4.

No outward changes since the endpoints are using the `NobodyValidator` which doesn't really look at tokens. When the validator gets switched, there will be a bigger impact and an outward facing change.