### PR TITLE
Move server into struct

### DIFF
--- a/architecture/butil.md
+++ b/architecture/butil.md
@@ -1,0 +1,113 @@
+# Command lines for the bendo command line utility
+
+Goal: Upload a directory of files into a bendo item on a remote bendo server.
+
+# Usage
+
+Suppose the server `bendo-staging.library.nd.edu:14000` contains an item named `abc123`.
+This item contains the following files:
+
+    abc123/
+        README
+        first.txt
+
+## Command line 1
+
+The first command line is
+
+    butil upload abc123 directory-name --server bendo-staging.library.nd.edu:14000
+
+This command will upload the files inside directory-name into the item "abc123" on the
+server "bendo-staging.library.nd.edu:14000". If the directory `directory-name` contains the following files:
+
+    directory-name/
+        first.txt
+        second.pdf
+        extra/
+            third.xls
+            fourth.csv
+
+Then the item "abc123" will be changed in the following way:
+
+    abc123/
+        README          (untouched)
+        first.txt       (updated with directory-name/first.txt)
+        second.pdf      (added from directory-name/second.pdf)
+        extra/
+            third.xls   (added from directory-name/extra/third.xls)
+            fourth.csv  (added from directory-name/extra/fourth.csv)
+
+## Command line 2
+
+The second command line is
+
+    butil upload abc123/extra/tenth.mp3 tenth.mp3 --server bendo-staging.library.nd.edu:14000
+
+This command will upload the file tenth.mp3 to the item "abc123" on the server "bendo-staging.library.nd.edu:14000". The item "abc123" will now look like this
+
+    abc123/
+        README          (untouched)
+        first.txt       (untouched)
+        extra/
+            tenth.mp3   (added)
+
+## Command line 3
+
+The third command line is
+
+    butil get abc123          --server bendo-staging.library.nd.edu:14000
+    butil get abc123 dest-dir --server bendo-staging.library.nd.edu:14000
+
+This command has two variants. The first one will download the complete contents
+of item "abc123" on the server "bendo-staging.library.nd.edu:14000" into the directory
+"abc123" inside the current working directory (creating it if it doesn't already exist.)
+
+    $CWD/abc123/
+        README      (created from abc123/README)
+        first.txt   (created from abc123/first.txt)
+
+The second command will download the contents of the given item into the directory `dest-dir` (creating the directory if it doesn't exist).
+
+    dest-dir/
+        README      (created from abc123/README)
+        first.txt   (created from abc123/first.txt)
+
+Note, the identifier given may contain a version marker, e.g. `abc123/@2`. It may also
+include a specific subdirectory or file inside the item, in which case only that subdirectory or item is downloaded. For example
+
+    abc123/@2        - Will download version 2 of the item "abc123"
+    abc123/extra     - If extra is a directory, will download only the contents of that
+    abc123/README    - Will only download the file README
+    abc123/@2/README - Will download the file README from version 2 of the item
+
+# Other uses
+
+This document has not given a way to perform the following operations on an item in a remote bendo server
+
+ * remove a single file
+ * rename a single file
+ * delete a blob
+ * update a file from a diff (i.e. a patching operation)
+
+The thought was that these could be done after the essential mechanism of uploading a directory of files was finished.
+
+# Appendix: Bendo item identifiers
+
+A bendo item identifier is any string meeting the following conditions
+
+ * It is at least 1 character long. (There is no specified maximum length. But we all know there is a practical maximum length. I don't know what that is).
+ * It does not contain a forward slash `/` or whitespace characters.
+ * It does not contain control characters.
+ * TBD: should all unicode characters be allowed.
+
+Individual files inside an item have identifiers based on the item's ID. They take
+two forms:
+
+    item-id/path/to/file
+    item-id/@2/path/to/file
+
+The first form refers to a file in the most recent version of the item. The
+second form refers to a file in a specific version of an item (in this case
+version 2). If a version is given which is not a positive integer or is a
+version which is larger than the current version of the item, then the
+identifier is invalid.

--- a/cmd/bendo/main.go
+++ b/cmd/bendo/main.go
@@ -24,12 +24,12 @@ func main() {
 	fmt.Printf("Using port number %s \n", *portNumber)
 	fmt.Printf("Using pprof port number %s \n", *pProfPort)
 	os.MkdirAll(*uploadDir, 0664)
-	server.Items = items.New(store.NewFileSystem(*storeDir))
-	server.TxStore = transaction.New(store.NewFileSystem(*uploadDir))
-	server.FileStore = fragment.New(store.NewFileSystem(*uploadDir))
-	var s server.RESTServer
-	s.PortNumber = *portNumber
-	s.PProfPort = *pProfPort
-	s.Items = server.Items
+	var s = server.RESTServer{
+		Items:      items.New(store.NewFileSystem(*storeDir)),
+		TxStore:    transaction.New(store.NewFileSystem(*uploadDir)),
+		FileStore:  fragment.New(store.NewFileSystem(*uploadDir)),
+		PortNumber: *portNumber,
+		PProfPort:  *pProfPort,
+	}
 	s.Run()
 }

--- a/cmd/bendo/main.go
+++ b/cmd/bendo/main.go
@@ -15,8 +15,8 @@ import (
 func main() {
 	var storeDir = flag.String("storage", ".", "location of the storage directory")
 	var uploadDir = flag.String("upload", "upload", "location of the upload directory")
-	var portNumber = flag.String("port", ":14000", "Port Number to Use")
-	var pProfPort = flag.String("pfport", ":14001", "PPROF Port Number to Use")
+	var portNumber = flag.String("port", "14000", "Port Number to Use")
+	var pProfPort = flag.String("pfport", "14001", "PPROF Port Number to Use")
 	flag.Parse()
 
 	fmt.Printf("Using storage dir %s\n", *storeDir)
@@ -27,7 +27,9 @@ func main() {
 	server.Items = items.New(store.NewFileSystem(*storeDir))
 	server.TxStore = transaction.New(store.NewFileSystem(*uploadDir))
 	server.FileStore = fragment.New(store.NewFileSystem(*uploadDir))
-	server.PortNumber = portNumber
-	server.PProfPort = pProfPort
-	server.Run()
+	var s server.RESTServer
+	s.PortNumber = *portNumber
+	s.PProfPort = *pProfPort
+	s.Items = server.Items
+	s.Run()
 }

--- a/items/item.go
+++ b/items/item.go
@@ -180,6 +180,35 @@ func (item Item) BlobByVersionSlot(vid VersionID, slot string) BlobID {
 	return 0
 }
 
+// BlobByExtendedSlot return the blob idenfifer for the given extended slot
+// name. An extended slot name is a slot name with an optional "@nnn/" prefix,
+// where nnn is the version number of the item to use (in decimal). If a
+// version prefix is not present, the most recent version of the item is used.
+// Like BlobByVersionSlot, 0 is returned if the slot path does not
+// resolve to anything.
+func (item Item) BlobByExtendedSlot(slot string) BlobID {
+	var vid VersionID
+	var vmax = item.Versions[len(item.Versions)-1].ID
+	if len(slot) >= 1 && slot[0] == '@' {
+		var err error
+		j := strings.Index(slot, "/")
+		if j >= 1 {
+			var v int64
+			// start from index 1 to skip initial "@"
+			v, err = strconv.ParseInt(slot[1:j], 10, 0)
+			vid = VersionID(v)
+		}
+		// if j was invalid, then vid == 0, so following will catch it
+		if err != nil || vid <= 0 || vid > vmax {
+			return 0
+		}
+		slot = slot[j+1:]
+	} else {
+		vid = vmax
+	}
+	return item.BlobByVersionSlot(vid, slot)
+}
+
 // used to implement a no-op cache
 type cache struct{}
 

--- a/items/item.go
+++ b/items/item.go
@@ -59,12 +59,12 @@ func sugar(id string, n int) string {
 // Returns an id of "" if the key could not be decoded.
 func desugar(s string) (id string, n int) {
 	s = strings.TrimSuffix(s, ".zip")
-	pieces := strings.Split(s, "-")
-	if len(pieces) != 2 {
+	j := strings.LastIndex(s, "-")
+	if j == -1 {
 		return "", 0
 	}
-	id = pieces[0]
-	n64, err := strconv.ParseInt(pieces[1], 10, 0)
+	id = s[0:j]
+	n64, err := strconv.ParseInt(s[j+1:], 10, 0)
 	if err != nil {
 		return "", 0
 	}

--- a/items/item_save_test.go
+++ b/items/item_save_test.go
@@ -13,7 +13,9 @@ func TestDecodeID(t *testing.T) {
 		{"xyz-0001", "xyz", 1},
 		{"b930agg8z-002003", "b930agg8z", 2003},
 		{"abcdefg", "", 0},
-		{"abc-0001-1", "", 0},
+		{"abc-0001-1", "abc-0001", 1},
+		{"abc-0001-2", "abc-0001", 2},
+		{"abc-0001-z", "", 0},
 	}
 	for _, test := range table {
 		s, n := desugar(test.input)

--- a/items/writer_test.go
+++ b/items/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"crypto/md5"
 	"crypto/sha256"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -227,6 +228,13 @@ func checkslots(t *testing.T, s *Store, id string, table []slotTriple) {
 	for _, triple := range table {
 		target := itm.BlobByVersionSlot(triple.version, triple.slot)
 		t.Logf("found (%d, %s) = %d", triple.version, triple.slot, target)
+		if target != triple.expectedBid {
+			t.Errorf("Received %d, expected %d", target, triple.expectedBid)
+		}
+
+		extslot := fmt.Sprintf("@%d/%s", triple.version, triple.slot)
+		target = itm.BlobByExtendedSlot(extslot)
+		t.Logf("found (%s) = %d", extslot, target)
 		if target != triple.expectedBid {
 			t.Errorf("Received %d, expected %d", target, triple.expectedBid)
 		}

--- a/server/bundle.go
+++ b/server/bundle.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ndlib/bendo/store"
 )
 
-func BundleListHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	c := Items.S.List()
+func (s *RESTServer) BundleListHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	c := s.Items.S.List()
 	// we encode this as JSON ourselves....how could it go wrong?
 	w.Write([]byte("["))
 	// comma starts as a space
@@ -24,9 +24,9 @@ func BundleListHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	w.Write([]byte("]"))
 }
 
-func BundleListPrefixHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) BundleListPrefixHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	prefix := ps.ByName("prefix")
-	result, err := Items.S.ListPrefix(prefix)
+	result, err := s.Items.S.ListPrefix(prefix)
 	if err != nil {
 		fmt.Fprintln(w, err)
 		return
@@ -35,9 +35,9 @@ func BundleListPrefixHandler(w http.ResponseWriter, r *http.Request, ps httprout
 	enc.Encode(result) // ignore any error
 }
 
-func BundleOpenHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) BundleOpenHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	key := ps.ByName("key")
-	data, _, err := Items.S.Open(key)
+	data, _, err := s.Items.S.Open(key)
 	if err != nil {
 		fmt.Fprintln(w, err)
 		return

--- a/server/db.go
+++ b/server/db.go
@@ -80,7 +80,7 @@ func UpdateChecksum(itemid string, status string) error {
 // store (which is the canonical source of information). Items which are
 // missing in the database will be added, and items in the database missing
 // from the store are removed from the database.
-func SyncItems() {
+func (s *RESTServer) SyncItems() {
 	const dbItemAddQL = `INSERT INTO items VALUES (?1, now(), "", ?2, now())`
 	const dbItemUpdateQL = `UPDATE items
 		data = ?2,
@@ -91,9 +91,9 @@ func SyncItems() {
 	// not synced with ours. Also do this before we start loading items
 	// since we do not know how long that will take.
 	updateTime := time.Now().Add(-1 * time.Hour)
-	for id := range Items.List() {
+	for id := range s.Items.List() {
 		// we force a reload of the JSON
-		item, err := Items.Item(id)
+		item, err := s.Items.Item(id)
 		if err != nil {
 			log.Printf(err.Error())
 			continue

--- a/server/item.go
+++ b/server/item.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ndlib/bendo/items"
 )
 
-func BlobHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) BlobHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	id := ps.ByName("id")
 	bid, err := strconv.ParseInt(ps.ByName("bid"), 10, 0)
 	if err != nil || bid <= 0 {
@@ -23,12 +23,12 @@ func BlobHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		return
 	}
 	w.Header().Set("ETag", fmt.Sprintf("%d", bid))
-	getblob(w, r, id, items.BlobID(bid))
+	s.getblob(w, r, id, items.BlobID(bid))
 }
 
-func SlotHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) SlotHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	id := ps.ByName("id")
-	item, err := Items.Item(id)
+	item, err := s.Items.Item(id)
 	if err != nil {
 		fmt.Fprintln(w, err.Error())
 		return
@@ -55,11 +55,11 @@ func SlotHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	}
 	w.Header().Set("Location", fmt.Sprintf("/blob/%s/%d", item.ID, bid))
 	w.Header().Set("Etag", fmt.Sprintf("%d", bid))
-	getblob(w, r, id, items.BlobID(bid))
+	s.getblob(w, r, id, items.BlobID(bid))
 }
 
-func getblob(w http.ResponseWriter, r *http.Request, id string, bid items.BlobID) {
-	src, err := Items.Blob(id, bid)
+func (s *RESTServer) getblob(w http.ResponseWriter, r *http.Request, id string, bid items.BlobID) {
+	src, err := s.Items.Blob(id, bid)
 	if err != nil {
 		w.WriteHeader(404)
 		fmt.Fprintln(w, err)
@@ -68,9 +68,9 @@ func getblob(w http.ResponseWriter, r *http.Request, id string, bid items.BlobID
 	io.Copy(w, src)
 }
 
-func ItemHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) ItemHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	id := ps.ByName("id")
-	item, err := Items.Item(id)
+	item, err := s.Items.Item(id)
 	if err != nil {
 		w.WriteHeader(404)
 		fmt.Fprintln(w, err.Error())

--- a/server/item.go
+++ b/server/item.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -55,7 +56,10 @@ func (s *RESTServer) getblob(w http.ResponseWriter, r *http.Request, id string, 
 		return
 	}
 	w.Header().Set("ETag", fmt.Sprintf("%d", bid))
-	io.Copy(w, src)
+	n, err := io.Copy(w, src)
+	if err != nil {
+		log.Printf("getblob (%s,%d) %d,%s", id, bid, n, err.Error())
+	}
 }
 
 func (s *RESTServer) ItemHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -71,12 +75,3 @@ func (s *RESTServer) ItemHandler(w http.ResponseWriter, r *http.Request, ps http
 	enc := json.NewEncoder(w)
 	enc.Encode(item)
 }
-
-// Wrap the item store in the singleflight so we only ask for metadata once
-
-/*
-// add  commit  button  to  item  info  page?
-	<form action="/transaction/{{ .ID }}/commit" method="post">
-		<button type="submit">Commit</button>
-	</form>
-*/

--- a/server/routes.go
+++ b/server/routes.go
@@ -83,8 +83,8 @@ func (s *RESTServer) addRoutes() http.Handler {
 	}{
 		{"GET", "/blob/:id/:bid", RoleRead, s.BlobHandler},
 		{"HEAD", "/blob/:id/:bid", RoleRead, s.BlobHandler},
-		{"GET", "/item/:id/:version/*slot", RoleRead, s.SlotHandler},
-		{"HEAD", "/item/:id/:version/*slot", RoleRead, s.SlotHandler},
+		{"GET", "/item/:id/*slot", RoleRead, s.SlotHandler},
+		{"HEAD", "/item/:id/*slot", RoleRead, s.SlotHandler},
 		{"GET", "/item/:id", RoleRead, s.ItemHandler},
 
 		// all the transaction things. Sooo many transaction things.

--- a/server/routes.go
+++ b/server/routes.go
@@ -85,9 +85,9 @@ func (s *RESTServer) addRoutes() http.Handler {
 		{"HEAD", "/blob/:id/:bid", RoleRead, s.BlobHandler},
 		{"GET", "/item/:id/*slot", RoleRead, s.SlotHandler},
 		{"HEAD", "/item/:id/*slot", RoleRead, s.SlotHandler},
-		{"GET", "/item/:id", RoleRead, s.ItemHandler},
+		{"GET", "/item/:id", RoleMDOnly, s.ItemHandler},
 
-		// all the transaction things. Sooo many transaction things.
+		// all the transaction things.
 		{"POST", "/item/:id/transaction", RoleWrite, NewTxHandler},
 		{"GET", "/transaction", RoleRead, ListTxHandler},
 		{"GET", "/transaction/:tid", RoleRead, TxInfoHandler},
@@ -130,6 +130,7 @@ func writeHTMLorJSON(w http.ResponseWriter,
 	r *http.Request,
 	tmpl *template.Template,
 	val interface{}) {
+
 	if r.Header.Get("Accept-Encoding") == "application/json" {
 		json.NewEncoder(w).Encode(val)
 		return

--- a/server/routes.go
+++ b/server/routes.go
@@ -15,56 +15,34 @@ import (
 	"github.com/ndlib/bendo/transaction"
 )
 
-var (
-	Items      *items.Store
-	TxStore    *transaction.Store
-	FileStore  *fragment.Store
-	PortNumber *string
-	PProfPort  *string
+// RESTServer is the base type containing the configuration for a Bendo REST
+// API server.
+//
+// Set all the public fields and then call Run. Run will listen on the given
+// port and handle requests. (At the moment there is no maximum simultaneous
+// request limit). Do not change any fields after calling Run.
+//
+// Run will start a goroutine to handle serializing new file uploads
+// into storage bags, and a goroutine to do fixity checking.
+type RESTServer struct {
+	PortNumber string
+	PProfPort  string
 	Validator  TokenValidator
-)
+	Items      *items.Store
+}
 
 var (
-	routes = []struct {
-		method  string
-		route   string
-		role    Role
-		handler httprouter.Handle
-	}{
-		{"GET", "/blob/:id/:bid", RoleRead, BlobHandler},
-		{"HEAD", "/blob/:id/:bid", RoleRead, BlobHandler},
-		{"GET", "/item/:id/:version/*slot", RoleRead, SlotHandler},
-		{"HEAD", "/item/:id/:version/*slot", RoleRead, SlotHandler},
-		{"GET", "/item/:id", RoleRead, ItemHandler},
-		// all the transaction things. Sooo many transaction things.
-		{"POST", "/item/:id/transaction", RoleWrite, NewTxHandler},
-		{"GET", "/transaction", RoleRead, ListTxHandler},
-		{"GET", "/transaction/:tid", RoleRead, TxInfoHandler},
-		{"POST", "/transaction/:tid/cancel", RoleWrite, CancelTxHandler}, //keep?
-		// file upload things
-		{"GET", "/upload", RoleRead, ListFileHandler},
-		{"POST", "/upload", RoleWrite, AppendFileHandler},
-		{"GET", "/upload/:fileid", RoleRead, GetFileHandler},
-		{"POST", "/upload/:fileid", RoleWrite, AppendFileHandler},
-		{"DELETE", "/upload/:fileid", RoleWrite, DeleteFileHandler},
-		{"GET", "/upload/:fileid/metadata", RoleMDOnly, GetFileInfoHandler},
-		{"PUT", "/upload/:fileid/metadata", RoleWrite, SetFileInfoHandler},
-		// the read only bundle stuff
-		{"GET", "/bundle/list/", RoleRead, BundleListHandler},
-		{"GET", "/bundle/listprefix/:prefix", RoleRead, BundleListPrefixHandler},
-		{"GET", "/bundle/open/:key", RoleRead, BundleOpenHandler},
-		// other
-		{"GET", "/", RoleUnknown, WelcomeHandler},
-		{"GET", "/stats", RoleUnknown, NotImplementedHandler},
-	}
+	Items     *items.Store
+	TxStore   *transaction.Store
+	FileStore *fragment.Store
 )
 
-func Run() {
+func (server *RESTServer) Run() {
 	log.Println("==========")
 	log.Println("Starting Bendo Server version", Version)
 
 	openDatabase("memory")
-	Validator = NewNobodyValidator()
+	server.Validator = NewNobodyValidator()
 
 	log.Println("Loading Transactions")
 	TxStore.Load()
@@ -74,11 +52,14 @@ func Run() {
 	go initCommitQueue()
 
 	// for pprof
-	go func() {
-		log.Println(http.ListenAndServe("localhost"+*PProfPort, nil))
-	}()
-	log.Println("Listening on ", PortNumber)
-	http.ListenAndServe(*PortNumber, AddRoutes())
+	if server.PProfPort != "" {
+		log.Println("Starting PProf on port", server.PProfPort)
+		go func() {
+			log.Println(http.ListenAndServe(":"+server.PProfPort, nil))
+		}()
+	}
+	log.Println("Listening on", server.PortNumber)
+	http.ListenAndServe(":"+server.PortNumber, server.addRoutes())
 }
 
 func initCommitQueue() {
@@ -93,13 +74,49 @@ func initCommitQueue() {
 	// also! put username into tx record
 }
 
-func AddRoutes() http.Handler {
-	r := httprouter.New()
+func (s *RESTServer) addRoutes() http.Handler {
+	var routes = []struct {
+		method  string
+		route   string
+		role    Role // RoleUnknown means no API key is needed to access
+		handler httprouter.Handle
+	}{
+		{"GET", "/blob/:id/:bid", RoleRead, s.BlobHandler},
+		{"HEAD", "/blob/:id/:bid", RoleRead, s.BlobHandler},
+		{"GET", "/item/:id/:version/*slot", RoleRead, s.SlotHandler},
+		{"HEAD", "/item/:id/:version/*slot", RoleRead, s.SlotHandler},
+		{"GET", "/item/:id", RoleRead, s.ItemHandler},
 
+		// all the transaction things. Sooo many transaction things.
+		{"POST", "/item/:id/transaction", RoleWrite, NewTxHandler},
+		{"GET", "/transaction", RoleRead, ListTxHandler},
+		{"GET", "/transaction/:tid", RoleRead, TxInfoHandler},
+		{"POST", "/transaction/:tid/cancel", RoleWrite, CancelTxHandler}, //keep?
+
+		// file upload things
+		{"GET", "/upload", RoleRead, ListFileHandler},
+		{"POST", "/upload", RoleWrite, AppendFileHandler},
+		{"GET", "/upload/:fileid", RoleRead, GetFileHandler},
+		{"POST", "/upload/:fileid", RoleWrite, AppendFileHandler},
+		{"DELETE", "/upload/:fileid", RoleWrite, DeleteFileHandler},
+		{"GET", "/upload/:fileid/metadata", RoleMDOnly, GetFileInfoHandler},
+		{"PUT", "/upload/:fileid/metadata", RoleWrite, SetFileInfoHandler},
+
+		// the read only bundle stuff
+		{"GET", "/bundle/list/:prefix", RoleRead, s.BundleListPrefixHandler},
+		{"GET", "/bundle/list/", RoleRead, s.BundleListHandler},
+		{"GET", "/bundle/open/:key", RoleRead, s.BundleOpenHandler},
+
+		// other
+		{"GET", "/", RoleUnknown, WelcomeHandler},
+		{"GET", "/stats", RoleUnknown, NotImplementedHandler},
+	}
+
+	r := httprouter.New()
 	for _, route := range routes {
 		r.Handle(route.method,
 			route.route,
-			checkTokenWrapper(route.handler, route.role))
+			s.authzWrapper(route.handler, route.role))
 	}
 	return r
 }
@@ -120,15 +137,13 @@ func writeHTMLorJSON(w http.ResponseWriter,
 	tmpl.Execute(w, val)
 }
 
-// checkTokenWrapper returns a Handler which will first verify the user token
-// as having at least the given Role. The user name is added as a parameter
+// authzWrapper returns a Handler which will first verify the user token as
+// having at least the given Role. The user name is added as a parameter
 // "username".
-func checkTokenWrapper(handler httprouter.Handle, leastRole Role) httprouter.Handle {
+func (server *RESTServer) authzWrapper(handler httprouter.Handle, leastRole Role) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		// user token exists? "X-Api-Key"
-
 		token := r.Header.Get("X-Api-Key")
-		user, role, err := Validator.TokenValid(token)
+		user, role, err := server.Validator.TokenValid(token)
 		if err != nil {
 			w.WriteHeader(500)
 			fmt.Fprintln(w, err.Error())
@@ -149,7 +164,7 @@ func checkTokenWrapper(handler httprouter.Handle, leastRole Role) httprouter.Han
 				goto out
 			}
 		}
-		// add a new username
+		// add a new username if none found
 		ps = append(ps, httprouter.Param{"username", user})
 	out:
 		handler(w, r, ps)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -236,10 +236,12 @@ func init() {
 	if err != nil {
 		log.Println(err.Error())
 	}
-	Validator = NewNobodyValidator()
 	Items = items.New(store.NewMemory())
 	TxStore = transaction.New(store.NewMemory())
 	TxStore.Load()
 	FileStore = fragment.New(store.NewMemory())
-	testServer = httptest.NewServer(AddRoutes())
+	server := new(RESTServer)
+	server.Validator = NewNobodyValidator()
+	server.Items = Items
+	testServer = httptest.NewServer(server.addRoutes())
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -236,12 +236,12 @@ func init() {
 	if err != nil {
 		log.Println(err.Error())
 	}
-	Items = items.New(store.NewMemory())
-	TxStore = transaction.New(store.NewMemory())
-	TxStore.Load()
-	FileStore = fragment.New(store.NewMemory())
-	server := new(RESTServer)
-	server.Validator = NewNobodyValidator()
-	server.Items = Items
+	server := &RESTServer{
+		Validator: NewNobodyValidator(),
+		Items:     items.New(store.NewMemory()),
+		TxStore:   transaction.New(store.NewMemory()),
+		FileStore: fragment.New(store.NewMemory()),
+	}
+	server.TxStore.Load()
 	testServer = httptest.NewServer(server.addRoutes())
 }

--- a/server/upload.go
+++ b/server/upload.go
@@ -17,12 +17,12 @@ import (
 )
 
 //{"GET", "/upload", ListFileHandler},
-func ListFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) ListFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	q := r.URL.Query()
 	if len(q["label"]) > 0 {
-		writeHTMLorJSON(w, r, listFileTemplate, FileStore.ListFiltered(q["label"]))
+		writeHTMLorJSON(w, r, listFileTemplate, s.FileStore.ListFiltered(q["label"]))
 	} else {
-		writeHTMLorJSON(w, r, listFileTemplate, FileStore.List())
+		writeHTMLorJSON(w, r, listFileTemplate, s.FileStore.List())
 	}
 }
 
@@ -40,9 +40,9 @@ var (
 )
 
 //{"GET", "/upload/:fileid/metadata", GetFileInfoHandler},
-func GetFileInfoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) GetFileInfoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	id := ps.ByName("fileid")
-	f := FileStore.Lookup(id)
+	f := s.FileStore.Lookup(id)
 	if f == nil {
 		w.WriteHeader(404)
 		fmt.Fprintln(w, "cannot find file")
@@ -72,7 +72,7 @@ var (
 
 //{"POST", "/upload", AppendFileHandler},
 //{"POST", "/upload/:fileid", AppendFileHandler},
-func AppendFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) AppendFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	md5hash64 := r.Header.Get("X-Upload-Md5")
 	sha256hash64 := r.Header.Get("X-Upload-Sha256")
 	if md5hash64 == "" && sha256hash64 == "" {
@@ -97,13 +97,13 @@ func AppendFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 	if fileid == "" {
 		for f == nil {
 			id := randomid()
-			f = FileStore.New(id)
+			f = s.FileStore.New(id)
 		}
 	} else {
 		// New returns nil if the file already exists!
-		f = FileStore.New(fileid)
+		f = s.FileStore.New(fileid)
 		if f == nil {
-			f = FileStore.Lookup(fileid)
+			f = s.FileStore.Lookup(fileid)
 		}
 		// f should not be nil at this point...
 		if f == nil {
@@ -157,9 +157,9 @@ func randomid() string {
 //{"DELETE", "/upload/:fileid", DeleteFileHandler},
 // This deletes a file which has been uploaded and is in the temporary
 // holding area.
-func DeleteFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) DeleteFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	fileid := ps.ByName("fileid")
-	err := FileStore.Delete(fileid)
+	err := s.FileStore.Delete(fileid)
 	if err != nil {
 		w.WriteHeader(500)
 		fmt.Fprintln(w, err.Error())
@@ -167,9 +167,9 @@ func DeleteFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 }
 
 //{"PUT", "/upload/:fileid/metadata", SetFileInfoHandler},
-func SetFileInfoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) SetFileInfoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	fileid := ps.ByName("fileid")
-	f := FileStore.Lookup(fileid)
+	f := s.FileStore.Lookup(fileid)
 	if f == nil {
 		w.WriteHeader(404)
 		fmt.Fprintln(w, "cannot find file")
@@ -192,9 +192,9 @@ func SetFileInfoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 }
 
 //{"GET", "/upload/:fileid", GetFileHandler},
-func GetFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (s *RESTServer) GetFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	fileid := ps.ByName("fileid")
-	f := FileStore.Lookup(fileid)
+	f := s.FileStore.Lookup(fileid)
 	if f == nil {
 		w.WriteHeader(404)
 		fmt.Fprintln(w, "Unknown file identifier")


### PR DESCRIPTION
This PR moves most of the server config into a structure. It also changes the item download URLs to use the new `item/@version/path/to/file` syntax, where the `@nnn` marks the specific version and is optional.