### PR TITLE
Add ability to shut down the server gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: go
 go:
  - 1.4
  - 1.5
+
+script: make test

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,10 +2,7 @@
 	"ImportPath": "github.com/ndlib/bendo",
 	"GoVersion": "go1.5.3",
 	"Packages": [
-		"./cmd/bclient",
-		"./cmd/bendo",
-		"./cmd/bstress",
-		"./cmd/butil"
+		"./cmd/..."
 	],
 	"Deps": [
 		{
@@ -52,6 +49,18 @@
 		{
 			"ImportPath": "github.com/cznic/zappy",
 			"Rev": "47331054e4f96186e3ff772877c0443909368a45"
+		},
+		{
+			"ImportPath": "github.com/facebookgo/clock",
+			"Rev": "600d898af40aa09a7a93ecb9265d87b0504b6f03"
+		},
+		{
+			"ImportPath": "github.com/facebookgo/httpdown",
+			"Rev": "1fa03998d20119dfe4ef73f56a638d83048052e2"
+		},
+		{
+			"ImportPath": "github.com/facebookgo/stats",
+			"Rev": "1b76add642e42c6ffba7211ad7b3939ce654526e"
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",

--- a/Godeps/_workspace/src/github.com/facebookgo/clock/LICENSE
+++ b/Godeps/_workspace/src/github.com/facebookgo/clock/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Godeps/_workspace/src/github.com/facebookgo/clock/README.md
+++ b/Godeps/_workspace/src/github.com/facebookgo/clock/README.md
@@ -1,0 +1,104 @@
+clock [![Build Status](https://drone.io/github.com/benbjohnson/clock/status.png)](https://drone.io/github.com/benbjohnson/clock/latest) [![Coverage Status](https://coveralls.io/repos/benbjohnson/clock/badge.png?branch=master)](https://coveralls.io/r/benbjohnson/clock?branch=master) [![GoDoc](https://godoc.org/github.com/benbjohnson/clock?status.png)](https://godoc.org/github.com/benbjohnson/clock) ![Project status](http://img.shields.io/status/experimental.png?color=red)
+=====
+
+Clock is a small library for mocking time in Go. It provides an interface
+around the standard library's [`time`][time] package so that the application
+can use the realtime clock while tests can use the mock clock.
+
+[time]: http://golang.org/pkg/time/
+
+
+## Usage
+
+### Realtime Clock
+
+Your application can maintain a `Clock` variable that will allow realtime and
+mock clocks to be interchangable. For example, if you had an `Application` type:
+
+```go
+import "github.com/benbjohnson/clock"
+
+type Application struct {
+	Clock clock.Clock
+}
+```
+
+You could initialize it to use the realtime clock like this:
+
+```go
+var app Application
+app.Clock = clock.New()
+...
+```
+
+Then all timers and time-related functionality should be performed from the
+`Clock` variable.
+
+
+### Mocking time
+
+In your tests, you will want to use a `Mock` clock:
+
+```go
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+)
+
+func TestApplication_DoSomething(t *testing.T) {
+	mock := clock.NewMock()
+	app := Application{Clock: mock}
+	...
+}
+```
+
+Now that you've initialized your application to use the mock clock, you can
+adjust the time programmatically. The mock clock always starts from the Unix
+epoch (midnight, Jan 1, 1970 UTC).
+
+
+### Controlling time
+
+The mock clock provides the same functions that the standard library's `time`
+package provides. For example, to find the current time, you use the `Now()`
+function:
+
+```go
+mock := clock.NewMock()
+
+// Find the current time.
+mock.Now().UTC() // 1970-01-01 00:00:00 +0000 UTC
+
+// Move the clock forward.
+mock.Add(2 * time.Hour)
+
+// Check the time again. It's 2 hours later!
+mock.Now().UTC() // 1970-01-01 02:00:00 +0000 UTC
+```
+
+Timers and Tickers are also controlled by this same mock clock. They will only
+execute when the clock is moved forward:
+
+```
+mock := clock.NewMock()
+count := 0
+
+// Kick off a timer to increment every 1 mock second.
+go func() {
+    ticker := clock.Ticker(1 * time.Second)
+    for {
+        <-ticker.C
+        count++
+    }
+}()
+runtime.Gosched()
+
+// Move the clock forward 10 second.
+mock.Add(10 * time.Second)
+
+// This prints 10.
+fmt.Println(count)
+```
+
+

--- a/Godeps/_workspace/src/github.com/facebookgo/clock/clock.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/clock/clock.go
@@ -1,0 +1,363 @@
+package clock
+
+import (
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Clock represents an interface to the functions in the standard library time
+// package. Two implementations are available in the clock package. The first
+// is a real-time clock which simply wraps the time package's functions. The
+// second is a mock clock which will only make forward progress when
+// programmatically adjusted.
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	AfterFunc(d time.Duration, f func()) *Timer
+	Now() time.Time
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+	Ticker(d time.Duration) *Ticker
+	Timer(d time.Duration) *Timer
+}
+
+// New returns an instance of a real-time clock.
+func New() Clock {
+	return &clock{}
+}
+
+// clock implements a real-time clock by simply wrapping the time package functions.
+type clock struct{}
+
+func (c *clock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (c *clock) AfterFunc(d time.Duration, f func()) *Timer {
+	return &Timer{timer: time.AfterFunc(d, f)}
+}
+
+func (c *clock) Now() time.Time { return time.Now() }
+
+func (c *clock) Sleep(d time.Duration) { time.Sleep(d) }
+
+func (c *clock) Tick(d time.Duration) <-chan time.Time { return time.Tick(d) }
+
+func (c *clock) Ticker(d time.Duration) *Ticker {
+	t := time.NewTicker(d)
+	return &Ticker{C: t.C, ticker: t}
+}
+
+func (c *clock) Timer(d time.Duration) *Timer {
+	t := time.NewTimer(d)
+	return &Timer{C: t.C, timer: t}
+}
+
+// Mock represents a mock clock that only moves forward programmically.
+// It can be preferable to a real-time clock when testing time-based functionality.
+type Mock struct {
+	mu     sync.Mutex
+	now    time.Time   // current time
+	timers clockTimers // tickers & timers
+
+	calls      Calls
+	waiting    []waiting
+	callsMutex sync.Mutex
+}
+
+// NewMock returns an instance of a mock clock.
+// The current time of the mock clock on initialization is the Unix epoch.
+func NewMock() *Mock {
+	return &Mock{now: time.Unix(0, 0)}
+}
+
+// Add moves the current time of the mock clock forward by the duration.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Add(d time.Duration) {
+	// Calculate the final current time.
+	t := m.now.Add(d)
+
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure the other goroutines get handled.
+	gosched()
+}
+
+// runNextTimer executes the next timer in chronological order and moves the
+// current time to the timer's next tick time. The next time is not executed if
+// it's next time if after the max time. Returns true if a timer is executed.
+func (m *Mock) runNextTimer(max time.Time) bool {
+	m.mu.Lock()
+
+	// Sort timers by time.
+	sort.Sort(m.timers)
+
+	// If we have no more timers then exit.
+	if len(m.timers) == 0 {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Retrieve next timer. Exit if next tick is after new time.
+	t := m.timers[0]
+	if t.Next().After(max) {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Move "now" forward and unlock clock.
+	m.now = t.Next()
+	m.mu.Unlock()
+
+	// Execute timer.
+	t.Tick(m.now)
+	return true
+}
+
+// After waits for the duration to elapse and then sends the current time on the returned channel.
+func (m *Mock) After(d time.Duration) <-chan time.Time {
+	defer m.inc(&m.calls.After)
+	return m.Timer(d).C
+}
+
+// AfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
+	defer m.inc(&m.calls.AfterFunc)
+	t := m.Timer(d)
+	t.C = nil
+	t.fn = f
+	return t
+}
+
+// Now returns the current wall time on the mock clock.
+func (m *Mock) Now() time.Time {
+	defer m.inc(&m.calls.Now)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.now
+}
+
+// Sleep pauses the goroutine for the given duration on the mock clock.
+// The clock must be moved forward in a separate goroutine.
+func (m *Mock) Sleep(d time.Duration) {
+	defer m.inc(&m.calls.Sleep)
+	<-m.After(d)
+}
+
+// Tick is a convenience function for Ticker().
+// It will return a ticker channel that cannot be stopped.
+func (m *Mock) Tick(d time.Duration) <-chan time.Time {
+	defer m.inc(&m.calls.Tick)
+	return m.Ticker(d).C
+}
+
+// Ticker creates a new instance of Ticker.
+func (m *Mock) Ticker(d time.Duration) *Ticker {
+	defer m.inc(&m.calls.Ticker)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time)
+	t := &Ticker{
+		C:    ch,
+		c:    ch,
+		mock: m,
+		d:    d,
+		next: m.now.Add(d),
+	}
+	m.timers = append(m.timers, (*internalTicker)(t))
+	return t
+}
+
+// Timer creates a new instance of Timer.
+func (m *Mock) Timer(d time.Duration) *Timer {
+	defer m.inc(&m.calls.Timer)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time)
+	t := &Timer{
+		C:    ch,
+		c:    ch,
+		mock: m,
+		next: m.now.Add(d),
+	}
+	m.timers = append(m.timers, (*internalTimer)(t))
+	return t
+}
+
+func (m *Mock) removeClockTimer(t clockTimer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, timer := range m.timers {
+		if timer == t {
+			copy(m.timers[i:], m.timers[i+1:])
+			m.timers[len(m.timers)-1] = nil
+			m.timers = m.timers[:len(m.timers)-1]
+			break
+		}
+	}
+	sort.Sort(m.timers)
+}
+
+func (m *Mock) inc(addr *uint32) {
+	m.callsMutex.Lock()
+	defer m.callsMutex.Unlock()
+	*addr++
+	var newWaiting []waiting
+	for _, w := range m.waiting {
+		if m.calls.atLeast(w.expected) {
+			close(w.done)
+			continue
+		}
+		newWaiting = append(newWaiting, w)
+	}
+	m.waiting = newWaiting
+}
+
+// Wait waits for at least the relevant calls before returning. The expected
+// Calls are always over the lifetime of the Mock. Values in the Calls struct
+// are used as the minimum number of calls, this allows you to wait for only
+// the calls you care about.
+func (m *Mock) Wait(s Calls) {
+	m.callsMutex.Lock()
+	if m.calls.atLeast(s) {
+		m.callsMutex.Unlock()
+		return
+	}
+	done := make(chan struct{})
+	m.waiting = append(m.waiting, waiting{expected: s, done: done})
+	m.callsMutex.Unlock()
+	<-done
+}
+
+// clockTimer represents an object with an associated start time.
+type clockTimer interface {
+	Next() time.Time
+	Tick(time.Time)
+}
+
+// clockTimers represents a list of sortable timers.
+type clockTimers []clockTimer
+
+func (a clockTimers) Len() int           { return len(a) }
+func (a clockTimers) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a clockTimers) Less(i, j int) bool { return a[i].Next().Before(a[j].Next()) }
+
+// Timer represents a single event.
+// The current time will be sent on C, unless the timer was created by AfterFunc.
+type Timer struct {
+	C     <-chan time.Time
+	c     chan time.Time
+	timer *time.Timer // realtime impl, if set
+	next  time.Time   // next tick time
+	mock  *Mock       // mock clock, if set
+	fn    func()      // AfterFunc function, if set
+}
+
+// Stop turns off the ticker.
+func (t *Timer) Stop() {
+	if t.timer != nil {
+		t.timer.Stop()
+	} else {
+		t.mock.removeClockTimer((*internalTimer)(t))
+	}
+}
+
+type internalTimer Timer
+
+func (t *internalTimer) Next() time.Time { return t.next }
+func (t *internalTimer) Tick(now time.Time) {
+	if t.fn != nil {
+		t.fn()
+	} else {
+		t.c <- now
+	}
+	t.mock.removeClockTimer((*internalTimer)(t))
+	gosched()
+}
+
+// Ticker holds a channel that receives "ticks" at regular intervals.
+type Ticker struct {
+	C      <-chan time.Time
+	c      chan time.Time
+	ticker *time.Ticker  // realtime impl, if set
+	next   time.Time     // next tick time
+	mock   *Mock         // mock clock, if set
+	d      time.Duration // time between ticks
+}
+
+// Stop turns off the ticker.
+func (t *Ticker) Stop() {
+	if t.ticker != nil {
+		t.ticker.Stop()
+	} else {
+		t.mock.removeClockTimer((*internalTicker)(t))
+	}
+}
+
+type internalTicker Ticker
+
+func (t *internalTicker) Next() time.Time { return t.next }
+func (t *internalTicker) Tick(now time.Time) {
+	select {
+	case t.c <- now:
+	case <-time.After(1 * time.Millisecond):
+	}
+	t.next = now.Add(t.d)
+	gosched()
+}
+
+// Sleep momentarily so that other goroutines can process.
+func gosched() { runtime.Gosched() }
+
+// Calls keeps track of the count of calls for each of the methods on the Clock
+// interface.
+type Calls struct {
+	After     uint32
+	AfterFunc uint32
+	Now       uint32
+	Sleep     uint32
+	Tick      uint32
+	Ticker    uint32
+	Timer     uint32
+}
+
+// atLeast returns true if at least the number of calls in o have been made.
+func (c Calls) atLeast(o Calls) bool {
+	if c.After < o.After {
+		return false
+	}
+	if c.AfterFunc < o.AfterFunc {
+		return false
+	}
+	if c.Now < o.Now {
+		return false
+	}
+	if c.Sleep < o.Sleep {
+		return false
+	}
+	if c.Tick < o.Tick {
+		return false
+	}
+	if c.Ticker < o.Ticker {
+		return false
+	}
+	if c.Timer < o.Timer {
+		return false
+	}
+	return true
+}
+
+type waiting struct {
+	expected Calls
+	done     chan struct{}
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/clock/clock_test.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/clock/clock_test.go
@@ -1,0 +1,536 @@
+package clock_test
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/facebookgo/clock"
+)
+
+// Ensure that the clock's After channel sends at the correct time.
+func TestClock_After(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		t.Fatal("too late")
+	}()
+	gosched()
+
+	<-clock.New().After(20 * time.Millisecond)
+	if !ok {
+		t.Fatal("too early")
+	}
+}
+
+// Ensure that the clock's AfterFunc executes at the correct time.
+func TestClock_AfterFunc(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		t.Fatal("too late")
+	}()
+	gosched()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	clock.New().AfterFunc(20*time.Millisecond, func() {
+		wg.Done()
+	})
+	wg.Wait()
+	if !ok {
+		t.Fatal("too early")
+	}
+}
+
+// Ensure that the clock's time matches the standary library.
+func TestClock_Now(t *testing.T) {
+	a := time.Now().Round(time.Second)
+	b := clock.New().Now().Round(time.Second)
+	if !a.Equal(b) {
+		t.Errorf("not equal: %s != %s", a, b)
+	}
+}
+
+// Ensure that the clock sleeps for the appropriate amount of time.
+func TestClock_Sleep(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		t.Fatal("too late")
+	}()
+	gosched()
+
+	clock.New().Sleep(20 * time.Millisecond)
+	if !ok {
+		t.Fatal("too early")
+	}
+}
+
+// Ensure that the clock ticks correctly.
+func TestClock_Tick(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		t.Fatal("too late")
+	}()
+	gosched()
+
+	c := clock.New().Tick(20 * time.Millisecond)
+	<-c
+	<-c
+	if !ok {
+		t.Fatal("too early")
+	}
+}
+
+// Ensure that the clock's ticker ticks correctly.
+func TestClock_Ticker(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		ok = true
+	}()
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		t.Fatal("too late")
+	}()
+	gosched()
+
+	ticker := clock.New().Ticker(50 * time.Millisecond)
+	<-ticker.C
+	<-ticker.C
+	if !ok {
+		t.Fatal("too early")
+	}
+}
+
+// Ensure that the clock's ticker can stop correctly.
+func TestClock_Ticker_Stp(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+	gosched()
+
+	ticker := clock.New().Ticker(20 * time.Millisecond)
+	<-ticker.C
+	ticker.Stop()
+	select {
+	case <-ticker.C:
+		t.Fatal("unexpected send")
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+// Ensure that the clock's timer waits correctly.
+func TestClock_Timer(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		t.Fatal("too late")
+	}()
+	gosched()
+
+	timer := clock.New().Timer(20 * time.Millisecond)
+	<-timer.C
+	if !ok {
+		t.Fatal("too early")
+	}
+}
+
+// Ensure that the clock's timer can be stopped.
+func TestClock_Timer_Stop(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ok = true
+	}()
+
+	timer := clock.New().Timer(20 * time.Millisecond)
+	timer.Stop()
+	select {
+	case <-timer.C:
+		t.Fatal("unexpected send")
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+// Ensure that the mock's After channel sends at the correct time.
+func TestMock_After(t *testing.T) {
+	var ok int32
+	clock := clock.NewMock()
+
+	// Create a channel to execute after 10 mock seconds.
+	ch := clock.After(10 * time.Second)
+	go func(ch <-chan time.Time) {
+		<-ch
+		atomic.StoreInt32(&ok, 1)
+	}(ch)
+
+	// Move clock forward to just before the time.
+	clock.Add(9 * time.Second)
+	if atomic.LoadInt32(&ok) == 1 {
+		t.Fatal("too early")
+	}
+
+	// Move clock forward to the after channel's time.
+	clock.Add(1 * time.Second)
+	if atomic.LoadInt32(&ok) == 0 {
+		t.Fatal("too late")
+	}
+}
+
+// Ensure that the mock's AfterFunc executes at the correct time.
+func TestMock_AfterFunc(t *testing.T) {
+	var ok int32
+	clock := clock.NewMock()
+
+	// Execute function after duration.
+	clock.AfterFunc(10*time.Second, func() {
+		atomic.StoreInt32(&ok, 1)
+	})
+
+	// Move clock forward to just before the time.
+	clock.Add(9 * time.Second)
+	if atomic.LoadInt32(&ok) == 1 {
+		t.Fatal("too early")
+	}
+
+	// Move clock forward to the after channel's time.
+	clock.Add(1 * time.Second)
+	if atomic.LoadInt32(&ok) == 0 {
+		t.Fatal("too late")
+	}
+}
+
+// Ensure that the mock's AfterFunc doesn't execute if stopped.
+func TestMock_AfterFunc_Stop(t *testing.T) {
+	// Execute function after duration.
+	clock := clock.NewMock()
+	timer := clock.AfterFunc(10*time.Second, func() {
+		t.Fatal("unexpected function execution")
+	})
+	gosched()
+
+	// Stop timer & move clock forward.
+	timer.Stop()
+	clock.Add(10 * time.Second)
+	gosched()
+}
+
+// Ensure that the mock's current time can be changed.
+func TestMock_Now(t *testing.T) {
+	clock := clock.NewMock()
+	if now := clock.Now(); !now.Equal(time.Unix(0, 0)) {
+		t.Fatalf("expected epoch, got: ", now)
+	}
+
+	// Add 10 seconds and check the time.
+	clock.Add(10 * time.Second)
+	if now := clock.Now(); !now.Equal(time.Unix(10, 0)) {
+		t.Fatalf("expected epoch, got: ", now)
+	}
+}
+
+// Ensure that the mock can sleep for the correct time.
+func TestMock_Sleep(t *testing.T) {
+	var ok int32
+	clock := clock.NewMock()
+
+	// Create a channel to execute after 10 mock seconds.
+	go func() {
+		clock.Sleep(10 * time.Second)
+		atomic.StoreInt32(&ok, 1)
+	}()
+	gosched()
+
+	// Move clock forward to just before the sleep duration.
+	clock.Add(9 * time.Second)
+	if atomic.LoadInt32(&ok) == 1 {
+		t.Fatal("too early")
+	}
+
+	// Move clock forward to the after the sleep duration.
+	clock.Add(1 * time.Second)
+	if atomic.LoadInt32(&ok) == 0 {
+		t.Fatal("too late")
+	}
+}
+
+// Ensure that the mock's Tick channel sends at the correct time.
+func TestMock_Tick(t *testing.T) {
+	var n int32
+	clock := clock.NewMock()
+
+	// Create a channel to increment every 10 seconds.
+	go func() {
+		tick := clock.Tick(10 * time.Second)
+		for {
+			<-tick
+			atomic.AddInt32(&n, 1)
+		}
+	}()
+	gosched()
+
+	// Move clock forward to just before the first tick.
+	clock.Add(9 * time.Second)
+	if atomic.LoadInt32(&n) != 0 {
+		t.Fatalf("expected 0, got %d", n)
+	}
+
+	// Move clock forward to the start of the first tick.
+	clock.Add(1 * time.Second)
+	if atomic.LoadInt32(&n) != 1 {
+		t.Fatalf("expected 1, got %d", n)
+	}
+
+	// Move clock forward over several ticks.
+	clock.Add(30 * time.Second)
+	if atomic.LoadInt32(&n) != 4 {
+		t.Fatalf("expected 4, got %d", n)
+	}
+}
+
+// Ensure that the mock's Ticker channel sends at the correct time.
+func TestMock_Ticker(t *testing.T) {
+	var n int32
+	clock := clock.NewMock()
+
+	// Create a channel to increment every microsecond.
+	go func() {
+		ticker := clock.Ticker(1 * time.Microsecond)
+		for {
+			<-ticker.C
+			atomic.AddInt32(&n, 1)
+		}
+	}()
+	gosched()
+
+	// Move clock forward.
+	clock.Add(10 * time.Microsecond)
+	if atomic.LoadInt32(&n) != 10 {
+		t.Fatalf("unexpected: %d", n)
+	}
+}
+
+// Ensure that the mock's Ticker channel won't block if not read from.
+func TestMock_Ticker_Overflow(t *testing.T) {
+	clock := clock.NewMock()
+	ticker := clock.Ticker(1 * time.Microsecond)
+	clock.Add(10 * time.Microsecond)
+	ticker.Stop()
+}
+
+// Ensure that the mock's Ticker can be stopped.
+func TestMock_Ticker_Stop(t *testing.T) {
+	var n int32
+	clock := clock.NewMock()
+
+	// Create a channel to increment every second.
+	ticker := clock.Ticker(1 * time.Second)
+	go func() {
+		for {
+			<-ticker.C
+			atomic.AddInt32(&n, 1)
+		}
+	}()
+	gosched()
+
+	// Move clock forward.
+	clock.Add(5 * time.Second)
+	if atomic.LoadInt32(&n) != 5 {
+		t.Fatalf("expected 5, got: %d", n)
+	}
+
+	ticker.Stop()
+
+	// Move clock forward again.
+	clock.Add(5 * time.Second)
+	if atomic.LoadInt32(&n) != 5 {
+		t.Fatalf("still expected 5, got: %d", n)
+	}
+}
+
+// Ensure that multiple tickers can be used together.
+func TestMock_Ticker_Multi(t *testing.T) {
+	var n int32
+	clock := clock.NewMock()
+
+	go func() {
+		a := clock.Ticker(1 * time.Microsecond)
+		b := clock.Ticker(3 * time.Microsecond)
+
+		for {
+			select {
+			case <-a.C:
+				atomic.AddInt32(&n, 1)
+			case <-b.C:
+				atomic.AddInt32(&n, 100)
+			}
+		}
+	}()
+	gosched()
+
+	// Move clock forward.
+	clock.Add(10 * time.Microsecond)
+	gosched()
+	if atomic.LoadInt32(&n) != 310 {
+		t.Fatalf("unexpected: %d", n)
+	}
+}
+
+func ExampleMock_After() {
+	// Create a new mock clock.
+	clock := clock.NewMock()
+	count := 0
+
+	// Create a channel to execute after 10 mock seconds.
+	go func() {
+		<-clock.After(10 * time.Second)
+		count = 100
+	}()
+	runtime.Gosched()
+
+	// Print the starting value.
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Move the clock forward 5 seconds and print the value again.
+	clock.Add(5 * time.Second)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Move the clock forward 5 seconds to the tick time and check the value.
+	clock.Add(5 * time.Second)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Output:
+	// 1970-01-01 00:00:00 +0000 UTC: 0
+	// 1970-01-01 00:00:05 +0000 UTC: 0
+	// 1970-01-01 00:00:10 +0000 UTC: 100
+}
+
+func ExampleMock_AfterFunc() {
+	// Create a new mock clock.
+	clock := clock.NewMock()
+	count := 0
+
+	// Execute a function after 10 mock seconds.
+	clock.AfterFunc(10*time.Second, func() {
+		count = 100
+	})
+	runtime.Gosched()
+
+	// Print the starting value.
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Move the clock forward 10 seconds and print the new value.
+	clock.Add(10 * time.Second)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Output:
+	// 1970-01-01 00:00:00 +0000 UTC: 0
+	// 1970-01-01 00:00:10 +0000 UTC: 100
+}
+
+func ExampleMock_Sleep() {
+	// Create a new mock clock.
+	clock := clock.NewMock()
+	count := 0
+
+	// Execute a function after 10 mock seconds.
+	go func() {
+		clock.Sleep(10 * time.Second)
+		count = 100
+	}()
+	runtime.Gosched()
+
+	// Print the starting value.
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Move the clock forward 10 seconds and print the new value.
+	clock.Add(10 * time.Second)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+
+	// Output:
+	// 1970-01-01 00:00:00 +0000 UTC: 0
+	// 1970-01-01 00:00:10 +0000 UTC: 100
+}
+
+func ExampleMock_Ticker() {
+	// Create a new mock clock.
+	clock := clock.NewMock()
+	count := 0
+
+	// Increment count every mock second.
+	go func() {
+		ticker := clock.Ticker(1 * time.Second)
+		for {
+			<-ticker.C
+			count++
+		}
+	}()
+	runtime.Gosched()
+
+	// Move the clock forward 10 seconds and print the new value.
+	clock.Add(10 * time.Second)
+	fmt.Printf("Count is %d after 10 seconds\n", count)
+
+	// Move the clock forward 5 more seconds and print the new value.
+	clock.Add(5 * time.Second)
+	fmt.Printf("Count is %d after 15 seconds\n", count)
+
+	// Output:
+	// Count is 10 after 10 seconds
+	// Count is 15 after 15 seconds
+}
+
+func ExampleMock_Timer() {
+	// Create a new mock clock.
+	clock := clock.NewMock()
+	count := 0
+
+	// Increment count after a mock second.
+	go func() {
+		timer := clock.Timer(1 * time.Second)
+		<-timer.C
+		count++
+	}()
+	runtime.Gosched()
+
+	// Move the clock forward 10 seconds and print the new value.
+	clock.Add(10 * time.Second)
+	fmt.Printf("Count is %d after 10 seconds\n", count)
+
+	// Output:
+	// Count is 1 after 10 seconds
+}
+
+func warn(v ...interface{})              { fmt.Fprintln(os.Stderr, v...) }
+func warnf(msg string, v ...interface{}) { fmt.Fprintf(os.Stderr, msg+"\n", v...) }
+
+func gosched() { time.Sleep(1 * time.Millisecond) }

--- a/Godeps/_workspace/src/github.com/facebookgo/httpdown/httpdown.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/httpdown/httpdown.go
@@ -1,0 +1,380 @@
+// Package httpdown provides http.ConnState enabled graceful termination of
+// http.Server.
+package httpdown
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/facebookgo/clock"
+	"github.com/facebookgo/stats"
+)
+
+const (
+	defaultStopTimeout = time.Minute
+	defaultKillTimeout = time.Minute
+)
+
+// A Server allows encapsulates the process of accepting new connections and
+// serving them, and gracefully shutting down the listener without dropping
+// active connections.
+type Server interface {
+	// Wait waits for the serving loop to finish. This will happen when Stop is
+	// called, at which point it returns no error, or if there is an error in the
+	// serving loop. You must call Wait after calling Serve or ListenAndServe.
+	Wait() error
+
+	// Stop stops the listener. It will block until all connections have been
+	// closed.
+	Stop() error
+}
+
+// HTTP defines the configuration for serving a http.Server. Multiple calls to
+// Serve or ListenAndServe can be made on the same HTTP instance. The default
+// timeouts of 1 minute each result in a maximum of 2 minutes before a Stop()
+// returns.
+type HTTP struct {
+	// StopTimeout is the duration before we begin force closing connections.
+	// Defaults to 1 minute.
+	StopTimeout time.Duration
+
+	// KillTimeout is the duration before which we completely give up and abort
+	// even though we still have connected clients. This is useful when a large
+	// number of client connections exist and closing them can take a long time.
+	// Note, this is in addition to the StopTimeout. Defaults to 1 minute.
+	KillTimeout time.Duration
+
+	// Stats is optional. If provided, it will be used to record various metrics.
+	Stats stats.Client
+
+	// Clock allows for testing timing related functionality. Do not specify this
+	// in production code.
+	Clock clock.Clock
+}
+
+// Serve provides the low-level API which is useful if you're creating your own
+// net.Listener.
+func (h HTTP) Serve(s *http.Server, l net.Listener) Server {
+	stopTimeout := h.StopTimeout
+	if stopTimeout == 0 {
+		stopTimeout = defaultStopTimeout
+	}
+	killTimeout := h.KillTimeout
+	if killTimeout == 0 {
+		killTimeout = defaultKillTimeout
+	}
+	klock := h.Clock
+	if klock == nil {
+		klock = clock.New()
+	}
+
+	ss := &server{
+		stopTimeout:  stopTimeout,
+		killTimeout:  killTimeout,
+		stats:        h.Stats,
+		clock:        klock,
+		oldConnState: s.ConnState,
+		listener:     l,
+		server:       s,
+		serveDone:    make(chan struct{}),
+		serveErr:     make(chan error, 1),
+		new:          make(chan net.Conn),
+		active:       make(chan net.Conn),
+		idle:         make(chan net.Conn),
+		closed:       make(chan net.Conn),
+		stop:         make(chan chan struct{}),
+		kill:         make(chan chan struct{}),
+	}
+	s.ConnState = ss.connState
+	go ss.manage()
+	go ss.serve()
+	return ss
+}
+
+// ListenAndServe returns a Server for the given http.Server. It is equivalent
+// to ListenAndServe from the standard library, but returns immediately.
+// Requests will be accepted in a background goroutine. If the http.Server has
+// a non-nil TLSConfig, a TLS enabled listener will be setup.
+func (h HTTP) ListenAndServe(s *http.Server) (Server, error) {
+	addr := s.Addr
+	if addr == "" {
+		if s.TLSConfig == nil {
+			addr = ":http"
+		} else {
+			addr = ":https"
+		}
+	}
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		stats.BumpSum(h.Stats, "listen.error", 1)
+		return nil, err
+	}
+	if s.TLSConfig != nil {
+		l = tls.NewListener(l, s.TLSConfig)
+	}
+	return h.Serve(s, l), nil
+}
+
+// server manages the serving process and allows for gracefully stopping it.
+type server struct {
+	stopTimeout time.Duration
+	killTimeout time.Duration
+	stats       stats.Client
+	clock       clock.Clock
+
+	oldConnState func(net.Conn, http.ConnState)
+	server       *http.Server
+	serveDone    chan struct{}
+	serveErr     chan error
+	listener     net.Listener
+
+	new    chan net.Conn
+	active chan net.Conn
+	idle   chan net.Conn
+	closed chan net.Conn
+	stop   chan chan struct{}
+	kill   chan chan struct{}
+
+	stopOnce sync.Once
+	stopErr  error
+}
+
+func (s *server) connState(c net.Conn, cs http.ConnState) {
+	if s.oldConnState != nil {
+		s.oldConnState(c, cs)
+	}
+
+	switch cs {
+	case http.StateNew:
+		s.new <- c
+	case http.StateActive:
+		s.active <- c
+	case http.StateIdle:
+		s.idle <- c
+	case http.StateHijacked, http.StateClosed:
+		s.closed <- c
+	}
+}
+
+func (s *server) manage() {
+	defer func() {
+		close(s.new)
+		close(s.active)
+		close(s.idle)
+		close(s.closed)
+		close(s.stop)
+		close(s.kill)
+	}()
+
+	var stopDone chan struct{}
+
+	conns := map[net.Conn]http.ConnState{}
+	var countNew, countActive, countIdle float64
+
+	// decConn decrements the count associated with the current state of the
+	// given connection.
+	decConn := func(c net.Conn) {
+		switch conns[c] {
+		default:
+			panic(fmt.Errorf("unknown existing connection: %s", c))
+		case http.StateNew:
+			countNew--
+		case http.StateActive:
+			countActive--
+		case http.StateIdle:
+			countIdle--
+		}
+	}
+
+	// setup a ticker to report various values every minute. if we don't have a
+	// Stats implementation provided, we Stop it so it never ticks.
+	statsTicker := s.clock.Ticker(time.Minute)
+	if s.stats == nil {
+		statsTicker.Stop()
+	}
+
+	for {
+		select {
+		case <-statsTicker.C:
+			// we'll only get here when s.stats is not nil
+			s.stats.BumpAvg("http-state.new", countNew)
+			s.stats.BumpAvg("http-state.active", countActive)
+			s.stats.BumpAvg("http-state.idle", countIdle)
+			s.stats.BumpAvg("http-state.total", countNew+countActive+countIdle)
+		case c := <-s.new:
+			conns[c] = http.StateNew
+			countNew++
+		case c := <-s.active:
+			decConn(c)
+			countActive++
+
+			conns[c] = http.StateActive
+		case c := <-s.idle:
+			decConn(c)
+			countIdle++
+
+			conns[c] = http.StateIdle
+
+			// if we're already stopping, close it
+			if stopDone != nil {
+				c.Close()
+			}
+		case c := <-s.closed:
+			stats.BumpSum(s.stats, "conn.closed", 1)
+			decConn(c)
+			delete(conns, c)
+
+			// if we're waiting to stop and are all empty, we just closed the last
+			// connection and we're done.
+			if stopDone != nil && len(conns) == 0 {
+				close(stopDone)
+				return
+			}
+		case stopDone = <-s.stop:
+			// if we're already all empty, we're already done
+			if len(conns) == 0 {
+				close(stopDone)
+				return
+			}
+
+			// close current idle connections right away
+			for c, cs := range conns {
+				if cs == http.StateIdle {
+					c.Close()
+				}
+			}
+
+			// continue the loop and wait for all the ConnState updates which will
+			// eventually close(stopDone) and return from this goroutine.
+
+		case killDone := <-s.kill:
+			// force close all connections
+			stats.BumpSum(s.stats, "kill.conn.count", float64(len(conns)))
+			for c := range conns {
+				c.Close()
+			}
+
+			// don't block the kill.
+			close(killDone)
+
+			// continue the loop and we wait for all the ConnState updates and will
+			// return from this goroutine when we're all done. otherwise we'll try to
+			// send those ConnState updates on closed channels.
+
+		}
+	}
+}
+
+func (s *server) serve() {
+	stats.BumpSum(s.stats, "serve", 1)
+	s.serveErr <- s.server.Serve(s.listener)
+	close(s.serveDone)
+	close(s.serveErr)
+}
+
+func (s *server) Wait() error {
+	if err := <-s.serveErr; !isUseOfClosedError(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *server) Stop() error {
+	s.stopOnce.Do(func() {
+		defer stats.BumpTime(s.stats, "stop.time").End()
+		stats.BumpSum(s.stats, "stop", 1)
+
+		// first disable keep-alive for new connections
+		s.server.SetKeepAlivesEnabled(false)
+
+		// then close the listener so new connections can't connect come thru
+		closeErr := s.listener.Close()
+		<-s.serveDone
+
+		// then trigger the background goroutine to stop and wait for it
+		stopDone := make(chan struct{})
+		s.stop <- stopDone
+
+		// wait for stop
+		select {
+		case <-stopDone:
+		case <-s.clock.After(s.stopTimeout):
+			defer stats.BumpTime(s.stats, "kill.time").End()
+			stats.BumpSum(s.stats, "kill", 1)
+
+			// stop timed out, wait for kill
+			killDone := make(chan struct{})
+			s.kill <- killDone
+			select {
+			case <-killDone:
+			case <-s.clock.After(s.killTimeout):
+				// kill timed out, give up
+				stats.BumpSum(s.stats, "kill.timeout", 1)
+			}
+		}
+
+		if closeErr != nil && !isUseOfClosedError(closeErr) {
+			stats.BumpSum(s.stats, "listener.close.error", 1)
+			s.stopErr = closeErr
+		}
+	})
+	return s.stopErr
+}
+
+func isUseOfClosedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if opErr, ok := err.(*net.OpError); ok {
+		err = opErr.Err
+	}
+	return err.Error() == "use of closed network connection"
+}
+
+// ListenAndServe is a convenience function to serve and wait for a SIGTERM
+// or SIGINT before shutting down.
+func ListenAndServe(s *http.Server, hd *HTTP) error {
+	if hd == nil {
+		hd = &HTTP{}
+	}
+	hs, err := hd.ListenAndServe(s)
+	if err != nil {
+		return err
+	}
+	log.Printf("serving on http://%s/ with pid %d\n", s.Addr, os.Getpid())
+
+	waiterr := make(chan error, 1)
+	go func() {
+		defer close(waiterr)
+		waiterr <- hs.Wait()
+	}()
+
+	signals := make(chan os.Signal, 10)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+
+	select {
+	case err := <-waiterr:
+		if err != nil {
+			return err
+		}
+	case s := <-signals:
+		signal.Stop(signals)
+		log.Printf("signal received: %s\n", s)
+		if err := hs.Stop(); err != nil {
+			return err
+		}
+		if err := <-waiterr; err != nil {
+			return err
+		}
+	}
+	log.Println("exiting")
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/httpdown/httpdown_example/main.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/httpdown/httpdown_example/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/facebookgo/httpdown"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	duration, err := time.ParseDuration(r.FormValue("duration"))
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	fmt.Fprintf(w, "going to sleep %s with pid %d\n", duration, os.Getpid())
+	w.(http.Flusher).Flush()
+	time.Sleep(duration)
+	fmt.Fprintf(w, "slept %s with pid %d\n", duration, os.Getpid())
+}
+
+func main() {
+	server := &http.Server{
+		Addr:    "127.0.0.1:8080",
+		Handler: http.HandlerFunc(handler),
+	}
+	hd := &httpdown.HTTP{
+		StopTimeout: 10 * time.Second,
+		KillTimeout: 1 * time.Second,
+	}
+
+	flag.StringVar(&server.Addr, "addr", server.Addr, "http address")
+	flag.DurationVar(&hd.StopTimeout, "stop-timeout", hd.StopTimeout, "stop timeout")
+	flag.DurationVar(&hd.KillTimeout, "kill-timeout", hd.KillTimeout, "kill timeout")
+	flag.Parse()
+
+	if err := httpdown.ListenAndServe(server, hd); err != nil {
+		panic(err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/httpdown/httpdown_test.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/httpdown/httpdown_test.go
@@ -1,0 +1,677 @@
+package httpdown_test
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/facebookgo/clock"
+	"github.com/facebookgo/ensure"
+	"github.com/facebookgo/freeport"
+	"github.com/facebookgo/httpdown"
+	"github.com/facebookgo/stats"
+)
+
+type onCloseListener struct {
+	net.Listener
+	mutex   sync.Mutex
+	onClose chan struct{}
+}
+
+func (o *onCloseListener) Close() error {
+	// Listener is closed twice, once by Grace, and once by the http library, so
+	// we guard against a double close of the chan.
+	defer func() {
+		o.mutex.Lock()
+		defer o.mutex.Unlock()
+		if o.onClose != nil {
+			close(o.onClose)
+			o.onClose = nil
+		}
+	}()
+	return o.Listener.Close()
+}
+
+func NewOnCloseListener(l net.Listener) (net.Listener, chan struct{}) {
+	c := make(chan struct{})
+	return &onCloseListener{Listener: l, onClose: c}, c
+}
+
+type closeErrListener struct {
+	net.Listener
+	err error
+}
+
+func (c *closeErrListener) Close() error {
+	c.Listener.Close()
+	return c.err
+}
+
+type acceptErrListener struct {
+	net.Listener
+	err chan error
+}
+
+func (c *acceptErrListener) Accept() (net.Conn, error) {
+	return nil, <-c.err
+}
+
+type closeErrConn struct {
+	net.Conn
+	unblockClose chan chan struct{}
+}
+
+func (c *closeErrConn) Close() error {
+	ch := <-c.unblockClose
+
+	// Close gets called multiple times, but only the first one gets this ch
+	if ch != nil {
+		defer close(ch)
+	}
+
+	return c.Conn.Close()
+}
+
+type closeErrConnListener struct {
+	net.Listener
+	unblockClose chan chan struct{}
+}
+
+func (l *closeErrConnListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return c, err
+	}
+	return &closeErrConn{Conn: c, unblockClose: l.unblockClose}, nil
+}
+
+func TestHTTPStopWithNoRequest(t *testing.T) {
+	t.Parallel()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+
+	statsDone := make(chan struct{}, 2)
+	hc := &stats.HookClient{
+		BumpSumHook: func(key string, val float64) {
+			if key == "serve" && val == 1 {
+				statsDone <- struct{}{}
+			}
+			if key == "stop" && val == 1 {
+				statsDone <- struct{}{}
+			}
+		},
+	}
+
+	server := &http.Server{}
+	down := &httpdown.HTTP{Stats: hc}
+	s := down.Serve(server, listener)
+	ensure.Nil(t, s.Stop())
+	<-statsDone
+	<-statsDone
+}
+
+func TestHTTPStopWithFinishedRequest(t *testing.T) {
+	t.Parallel()
+	hello := []byte("hello")
+	fin := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(fin)
+		w.Write(hello)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+	actualBody, err := ioutil.ReadAll(res.Body)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, actualBody, hello)
+	ensure.Nil(t, res.Body.Close())
+
+	// At this point the request is finished, and the connection should be alive
+	// but idle (because we have keep alive enabled by default in our Transport).
+	ensure.Nil(t, s.Stop())
+	<-fin
+
+	ensure.Nil(t, s.Wait())
+}
+
+func TestHTTPStopWithActiveRequest(t *testing.T) {
+	t.Parallel()
+	const count = 10000
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.WriteHeader(200)
+		for i := 0; i < count; i++ {
+			w.Write(hello)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	actualBody, err := ioutil.ReadAll(res.Body)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, actualBody, bytes.Repeat(hello, count))
+	ensure.Nil(t, res.Body.Close())
+	<-finOkHandler
+	<-finStop
+}
+
+func TestNewRequestAfterStop(t *testing.T) {
+	t.Parallel()
+	const count = 10000
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	unblockOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.WriteHeader(200)
+		const diff = 500
+		for i := 0; i < count-diff; i++ {
+			w.Write(hello)
+		}
+		<-unblockOkHandler
+		for i := 0; i < diff; i++ {
+			w.Write(hello)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, onClose := NewOnCloseListener(listener)
+	ensure.Nil(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	// Wait until the listener is closed.
+	<-onClose
+
+	// Now the next request should not be able to connect as the listener is
+	// now closed.
+	_, err = client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+
+	// We should just get "connection refused" here, but sometimes, very rarely,
+	// we get a "connection reset" instead. Unclear why this happens.
+	ensure.Err(t, err, regexp.MustCompile("(connection refused|connection reset by peer)$"))
+
+	// Unblock the handler and ensure we finish writing the rest of the body
+	// successfully.
+	close(unblockOkHandler)
+	actualBody, err := ioutil.ReadAll(res.Body)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, actualBody, bytes.Repeat(hello, count))
+	ensure.Nil(t, res.Body.Close())
+	<-finOkHandler
+	<-finStop
+}
+
+func TestHTTPListenerCloseError(t *testing.T) {
+	t.Parallel()
+	expectedError := errors.New("foo")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener = &closeErrListener{Listener: listener, err: expectedError}
+	ensure.Nil(t, err)
+	server := &http.Server{}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	ensure.DeepEqual(t, s.Stop(), expectedError)
+}
+
+func TestHTTPServeError(t *testing.T) {
+	t.Parallel()
+	expectedError := errors.New("foo")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	errChan := make(chan error)
+	listener = &acceptErrListener{Listener: listener, err: errChan}
+	ensure.Nil(t, err)
+	server := &http.Server{}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	errChan <- expectedError
+	ensure.DeepEqual(t, s.Wait(), expectedError)
+	ensure.Nil(t, s.Stop())
+}
+
+func TestHTTPWithinStopTimeout(t *testing.T) {
+	t.Parallel()
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.WriteHeader(200)
+		w.Write(hello)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{StopTimeout: time.Minute}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	actualBody, err := ioutil.ReadAll(res.Body)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, actualBody, hello)
+	ensure.Nil(t, res.Body.Close())
+	<-finOkHandler
+	<-finStop
+}
+
+func TestHTTPStopTimeoutMissed(t *testing.T) {
+	t.Parallel()
+
+	klock := clock.NewMock()
+
+	const count = 10000
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	unblockOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.Header().Set("Content-Length", fmt.Sprint(len(hello)*count))
+		w.WriteHeader(200)
+		for i := 0; i < count/2; i++ {
+			w.Write(hello)
+		}
+		<-unblockOkHandler
+		for i := 0; i < count/2; i++ {
+			w.Write(hello)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{
+		StopTimeout: time.Minute,
+		Clock:       klock,
+	}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	klock.Wait(clock.Calls{After: 1}) // wait for Stop to call After
+	klock.Add(down.StopTimeout)
+
+	_, err = ioutil.ReadAll(res.Body)
+	ensure.Err(t, err, regexp.MustCompile("^unexpected EOF$"))
+	ensure.Nil(t, res.Body.Close())
+	close(unblockOkHandler)
+	<-finOkHandler
+	<-finStop
+}
+
+func TestHTTPKillTimeout(t *testing.T) {
+	t.Parallel()
+
+	klock := clock.NewMock()
+
+	statsDone := make(chan struct{}, 1)
+	hc := &stats.HookClient{
+		BumpSumHook: func(key string, val float64) {
+			if key == "kill" && val == 1 {
+				statsDone <- struct{}{}
+			}
+		},
+	}
+
+	const count = 10000
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	unblockOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.Header().Set("Content-Length", fmt.Sprint(len(hello)*count))
+		w.WriteHeader(200)
+		for i := 0; i < count/2; i++ {
+			w.Write(hello)
+		}
+		<-unblockOkHandler
+		for i := 0; i < count/2; i++ {
+			w.Write(hello)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{
+		StopTimeout: time.Minute,
+		KillTimeout: time.Minute,
+		Stats:       hc,
+		Clock:       klock,
+	}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	klock.Wait(clock.Calls{After: 1}) // wait for Stop to call After
+	klock.Add(down.StopTimeout)
+
+	_, err = ioutil.ReadAll(res.Body)
+	ensure.Err(t, err, regexp.MustCompile("^unexpected EOF$"))
+	ensure.Nil(t, res.Body.Close())
+	close(unblockOkHandler)
+	<-finOkHandler
+	<-finStop
+	<-statsDone
+}
+
+func TestHTTPKillTimeoutMissed(t *testing.T) {
+	t.Parallel()
+
+	klock := clock.NewMock()
+
+	statsDone := make(chan struct{}, 1)
+	hc := &stats.HookClient{
+		BumpSumHook: func(key string, val float64) {
+			if key == "kill.timeout" && val == 1 {
+				statsDone <- struct{}{}
+			}
+		},
+	}
+
+	const count = 10000
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	unblockOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.Header().Set("Content-Length", fmt.Sprint(len(hello)*count))
+		w.WriteHeader(200)
+		for i := 0; i < count/2; i++ {
+			w.Write(hello)
+		}
+		<-unblockOkHandler
+		for i := 0; i < count/2; i++ {
+			w.Write(hello)
+		}
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	unblockConnClose := make(chan chan struct{}, 1)
+	listener = &closeErrConnListener{
+		Listener:     listener,
+		unblockClose: unblockConnClose,
+	}
+
+	server := &http.Server{Handler: http.HandlerFunc(okHandler)}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{
+		StopTimeout: time.Minute,
+		KillTimeout: time.Minute,
+		Stats:       hc,
+		Clock:       klock,
+	}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+
+	// Start the Stop process.
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	klock.Wait(clock.Calls{After: 1}) // wait for Stop to call After
+	klock.Add(down.StopTimeout)       // trigger stop timeout
+	klock.Wait(clock.Calls{After: 2}) // wait for Kill to call After
+	klock.Add(down.KillTimeout)       // trigger kill timeout
+
+	// We hit both the StopTimeout & the KillTimeout.
+	<-finStop
+
+	// Then we unblock the Close, so we get an unexpected EOF since we close
+	// before we finish writing the response.
+	connCloseDone := make(chan struct{})
+	unblockConnClose <- connCloseDone
+	<-connCloseDone
+	close(unblockConnClose)
+
+	// Then we unblock the handler which tries to write the rest of the data.
+	close(unblockOkHandler)
+
+	_, err = ioutil.ReadAll(res.Body)
+	ensure.Err(t, err, regexp.MustCompile("^unexpected EOF$"))
+	ensure.Nil(t, res.Body.Close())
+	<-finOkHandler
+	<-statsDone
+}
+
+func TestDoubleStop(t *testing.T) {
+	t.Parallel()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	ensure.Nil(t, s.Stop())
+	ensure.Nil(t, s.Stop())
+}
+
+func TestExistingConnState(t *testing.T) {
+	t.Parallel()
+	hello := []byte("hello")
+	fin := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(fin)
+		w.Write(hello)
+	}
+
+	var called int32
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	ensure.Nil(t, err)
+	server := &http.Server{
+		Handler: http.HandlerFunc(okHandler),
+		ConnState: func(c net.Conn, s http.ConnState) {
+			atomic.AddInt32(&called, 1)
+		},
+	}
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{}
+	s := down.Serve(server, listener)
+	res, err := client.Get(fmt.Sprintf("http://%s/", listener.Addr().String()))
+	ensure.Nil(t, err)
+	actualBody, err := ioutil.ReadAll(res.Body)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, actualBody, hello)
+	ensure.Nil(t, res.Body.Close())
+
+	ensure.Nil(t, s.Stop())
+	<-fin
+
+	ensure.True(t, atomic.LoadInt32(&called) > 0)
+}
+
+func TestHTTPDefaultListenError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cant run this test as root")
+	}
+
+	statsDone := make(chan struct{}, 1)
+	hc := &stats.HookClient{
+		BumpSumHook: func(key string, val float64) {
+			if key == "listen.error" && val == 1 {
+				statsDone <- struct{}{}
+			}
+		},
+	}
+
+	t.Parallel()
+	down := &httpdown.HTTP{Stats: hc}
+	_, err := down.ListenAndServe(&http.Server{})
+	ensure.Err(t, err, regexp.MustCompile("listen tcp :80: bind: permission denied"))
+	<-statsDone
+}
+
+func TestHTTPSDefaultListenError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cant run this test as root")
+	}
+	t.Parallel()
+
+	cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+	if err != nil {
+		t.Fatalf("error loading cert: %v", err)
+	}
+
+	down := &httpdown.HTTP{}
+	_, err = down.ListenAndServe(&http.Server{
+		TLSConfig: &tls.Config{
+			NextProtos:   []string{"http/1.1"},
+			Certificates: []tls.Certificate{cert},
+		},
+	})
+	ensure.Err(t, err, regexp.MustCompile("listen tcp :443: bind: permission denied"))
+}
+
+func TestTLS(t *testing.T) {
+	t.Parallel()
+	port, err := freeport.Get()
+	ensure.Nil(t, err)
+
+	cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+	if err != nil {
+		t.Fatalf("error loading cert: %v", err)
+	}
+	const count = 10000
+	hello := []byte("hello")
+	finOkHandler := make(chan struct{})
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(finOkHandler)
+		w.WriteHeader(200)
+		for i := 0; i < count; i++ {
+			w.Write(hello)
+		}
+	}
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
+		Handler: http.HandlerFunc(okHandler),
+		TLSConfig: &tls.Config{
+			NextProtos:   []string{"http/1.1"},
+			Certificates: []tls.Certificate{cert},
+		},
+	}
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	client := &http.Client{Transport: transport}
+	down := &httpdown.HTTP{}
+	s, err := down.ListenAndServe(server)
+	ensure.Nil(t, err)
+	res, err := client.Get(fmt.Sprintf("https://%s/", server.Addr))
+	ensure.Nil(t, err)
+
+	finStop := make(chan struct{})
+	go func() {
+		defer close(finStop)
+		ensure.Nil(t, s.Stop())
+	}()
+
+	actualBody, err := ioutil.ReadAll(res.Body)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, actualBody, bytes.Repeat(hello, count))
+	ensure.Nil(t, res.Body.Close())
+	<-finOkHandler
+	<-finStop
+}
+
+// localhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at the last second of 2049 (the end
+// of ASN.1 time).
+// generated from src/pkg/crypto/tls:
+// go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
+bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
+bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBALyCfqwwip8BvTKgVKGdmjZTU8DD
+ndR+WALmFPIRqn89bOU3s30olKiqYEju/SFoEvMyFRT/TWEhXHDaufThqaMCAwEA
+AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
+AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAr/09uy108p51rheIOSnz4zgduyTl
+M+4AmRo8/U1twEZLgfAGG/GZjREv2y4mCEUIM3HebCAqlA5jpRg76Rf8jw==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOQIBAAJBALyCfqwwip8BvTKgVKGdmjZTU8DDndR+WALmFPIRqn89bOU3s30o
+lKiqYEju/SFoEvMyFRT/TWEhXHDaufThqaMCAwEAAQJAPXuWUxTV8XyAt8VhNQER
+LgzJcUKb9JVsoS1nwXgPksXnPDKnL9ax8VERrdNr+nZbj2Q9cDSXBUovfdtehcdP
+qQIhAO48ZsPylbTrmtjDEKiHT2Ik04rLotZYS2U873J6I7WlAiEAypDjYxXyafv/
+Yo1pm9onwcetQKMW8CS3AjuV9Axzj6cCIEx2Il19fEMG4zny0WPlmbrcKvD/DpJQ
+4FHrzsYlIVTpAiAas7S1uAvneqd0l02HlN9OxQKKlbUNXNme+rnOnOGS2wIgS0jW
+zl1jvrOSJeP1PpAHohWz6LOhEr8uvltWkN6x3vE=
+-----END RSA PRIVATE KEY-----`)

--- a/Godeps/_workspace/src/github.com/facebookgo/httpdown/license
+++ b/Godeps/_workspace/src/github.com/facebookgo/httpdown/license
@@ -1,0 +1,30 @@
+BSD License
+
+For httpdown software
+
+Copyright (c) 2015, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Godeps/_workspace/src/github.com/facebookgo/httpdown/patents
+++ b/Godeps/_workspace/src/github.com/facebookgo/httpdown/patents
@@ -1,0 +1,33 @@
+Additional Grant of Patent Rights Version 2
+
+"Software" means the httpdown software distributed by Facebook, Inc.
+
+Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
+("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook’s rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/Godeps/_workspace/src/github.com/facebookgo/httpdown/readme.md
+++ b/Godeps/_workspace/src/github.com/facebookgo/httpdown/readme.md
@@ -1,0 +1,41 @@
+httpdown [![Build Status](https://secure.travis-ci.org/facebookgo/httpdown.png)](https://travis-ci.org/facebookgo/httpdown)
+========
+
+Documentation: https://godoc.org/github.com/facebookgo/httpdown
+
+Package httpdown provides a library that makes it easy to build a HTTP server
+that can be shutdown gracefully (that is, without dropping any connections).
+
+If you want graceful restart and not just graceful shutdown, look at the
+[grace](https://github.com/facebookgo/grace) package which uses this package
+underneath but also provides graceful restart.
+
+Usage
+-----
+
+Demo HTTP Server with graceful termination:
+https://github.com/facebookgo/httpdown/blob/master/httpdown_example/main.go
+
+1. Install the demo application
+
+        go get github.com/facebookgo/httpdown/httpdown_example
+
+1. Start it in the first terminal
+
+        httpdown_example
+
+   This will output something like:
+
+        2014/11/18 21:57:50 serving on http://127.0.0.1:8080/ with pid 17
+
+1. In a second terminal start a slow HTTP request
+
+        curl 'http://localhost:8080/?duration=20s'
+
+1. In a third terminal trigger a graceful shutdown (using the pid from your output):
+
+        kill -TERM 17
+
+This will demonstrate that the slow request was served before the server was
+shutdown. You could also have used `Ctrl-C` instead of `kill` as the example
+application triggers graceful shutdown on TERM or INT signals.

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/aggregation.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/aggregation.go
@@ -1,0 +1,35 @@
+package stats
+
+import "sort"
+
+// Average returns the average value
+func Average(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	var val float64
+	for _, point := range values {
+		val += point
+	}
+	return val / float64(len(values))
+}
+
+// Sum returns the sum of all the given values
+func Sum(values []float64) float64 {
+	var val float64
+	for _, point := range values {
+		val += point
+	}
+	return val
+}
+
+// Percentiles returns a map containing the asked for percentiles
+func Percentiles(values []float64, percentiles map[string]float64) map[string]float64 {
+	sort.Float64s(values)
+	results := map[string]float64{}
+	for label, p := range percentiles {
+		results[label] = values[int(float64(len(values))*p)]
+	}
+	return results
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/aggregation_test.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/aggregation_test.go
@@ -1,0 +1,38 @@
+package stats_test
+
+import (
+	"testing"
+
+	"github.com/facebookgo/ensure"
+	"github.com/facebookgo/stats"
+)
+
+func TestAverage(t *testing.T) {
+	t.Parallel()
+	ensure.DeepEqual(t, stats.Average([]float64{}), 0.0)
+	ensure.DeepEqual(t, stats.Average([]float64{1}), 1.0)
+	ensure.DeepEqual(t, stats.Average([]float64{1, 2}), 1.5)
+	ensure.DeepEqual(t, stats.Average([]float64{1, 2, 3}), 2.0)
+}
+
+func TestSum(t *testing.T) {
+	t.Parallel()
+	ensure.DeepEqual(t, stats.Sum([]float64{}), 0.0)
+	ensure.DeepEqual(t, stats.Sum([]float64{1}), 1.0)
+	ensure.DeepEqual(t, stats.Sum([]float64{1, 2}), 3.0)
+	ensure.DeepEqual(t, stats.Sum([]float64{1, 2, 3}), 6.0)
+}
+
+func TestPercentiles(t *testing.T) {
+	t.Parallel()
+	percentiles := map[string]float64{
+		"p50": 0.5,
+		"p90": 0.9,
+	}
+	input := []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	expected := map[string]float64{
+		"p50": 5,
+		"p90": 9,
+	}
+	ensure.DeepEqual(t, stats.Percentiles(input, percentiles), expected)
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/counter.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/counter.go
@@ -1,0 +1,112 @@
+package stats
+
+import "fmt"
+
+// Type is the type of aggregation of apply
+type Type int
+
+const (
+	AggregateAvg Type = iota
+	AggregateSum
+	AggregateHistogram
+)
+
+var (
+	// HistogramPercentiles is used to determine which percentiles to return for
+	// SimpleCounter.Aggregate
+	HistogramPercentiles = map[string]float64{
+		"p50": 0.5,
+		"p95": 0.95,
+		"p99": 0.99,
+	}
+
+	// MinSamplesForPercentiles is used by SimpleCounter.Aggregate to determine
+	// what the minimum number of samples is required for percentile analysis
+	MinSamplesForPercentiles = 10
+)
+
+// Aggregates can be used to merge counters together. This is not goroutine safe
+type Aggregates map[string]Counter
+
+// Add adds the counter for aggregation. This is not goroutine safe
+func (a Aggregates) Add(c Counter) error {
+	key := c.FullKey()
+	if counter, ok := a[key]; ok {
+		if counter.GetType() != c.GetType() {
+			return fmt.Errorf("stats: mismatched aggregation type for: %s", key)
+		}
+		counter.AddValues(c.GetValues()...)
+	} else {
+		a[key] = c
+	}
+	return nil
+}
+
+// Counter is the interface used by Aggregates to merge counters together
+type Counter interface {
+	// FullKey is used to uniquely identify the counter
+	FullKey() string
+
+	// AddValues adds values for aggregation
+	AddValues(...float64)
+
+	// GetValues returns the values for aggregation
+	GetValues() []float64
+
+	// GetType returns the type of aggregation to apply
+	GetType() Type
+}
+
+// SimpleCounter is a basic implementation of the Counter interface
+type SimpleCounter struct {
+	Key    string
+	Values []float64
+	Type   Type
+}
+
+// FullKey is part of the Counter interace
+func (s *SimpleCounter) FullKey() string {
+	return s.Key
+}
+
+// GetValues is part of the Counter interface
+func (s *SimpleCounter) GetValues() []float64 {
+	return s.Values
+}
+
+// AddValues is part of the Counter interface
+func (s *SimpleCounter) AddValues(vs ...float64) {
+	s.Values = append(s.Values, vs...)
+}
+
+// GetType is part of the Counter interface
+func (s *SimpleCounter) GetType() Type {
+	return s.Type
+}
+
+// Aggregate aggregates the provided values appropriately, returning a map
+// from key to value. If AggregateHistogram is specified, the map will contain
+// the relevant percentiles as specified by HistogramPercentiles
+func (s *SimpleCounter) Aggregate() map[string]float64 {
+	switch s.Type {
+	case AggregateAvg:
+		return map[string]float64{
+			s.Key: Average(s.Values),
+		}
+	case AggregateSum:
+		return map[string]float64{
+			s.Key: Sum(s.Values),
+		}
+	case AggregateHistogram:
+		histogram := map[string]float64{
+			s.Key: Average(s.Values),
+		}
+		if len(s.Values) > MinSamplesForPercentiles {
+			for k, v := range Percentiles(s.Values, HistogramPercentiles) {
+				histogram[fmt.Sprintf("%s.%s", s.Key, k)] = v
+			}
+		}
+		return histogram
+	}
+	panic("stats: unsupported aggregation type")
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/counter_test.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/counter_test.go
@@ -1,0 +1,60 @@
+package stats_test
+
+import (
+	"testing"
+
+	"github.com/facebookgo/ensure"
+	"github.com/facebookgo/stats"
+)
+
+func TestSimpleCounterAggregation(t *testing.T) {
+	t.Parallel()
+
+	a := stats.Aggregates{}
+	a.Add(&stats.SimpleCounter{
+		Key:    "foo.avg",
+		Values: []float64{1},
+		Type:   stats.AggregateAvg,
+	})
+	a.Add(&stats.SimpleCounter{
+		Key:    "foo.sum",
+		Values: []float64{1},
+		Type:   stats.AggregateSum,
+	})
+	a.Add(&stats.SimpleCounter{
+		Key:    "foo.time",
+		Values: []float64{0, 1, 2, 3, 4},
+		Type:   stats.AggregateHistogram,
+	})
+	a.Add(&stats.SimpleCounter{
+		Key:    "foo.sum",
+		Values: []float64{2},
+		Type:   stats.AggregateSum,
+	})
+	a.Add(&stats.SimpleCounter{
+		Key:    "foo.time",
+		Values: []float64{5, 6, 7, 8, 9, 10},
+		Type:   stats.AggregateHistogram,
+	})
+	a.Add(&stats.SimpleCounter{
+		Key:    "foo.avg",
+		Values: []float64{2},
+		Type:   stats.AggregateAvg,
+	})
+
+	all := map[string]float64{}
+	for _, counter := range a {
+		for key, value := range counter.(*stats.SimpleCounter).Aggregate() {
+			all[key] = value
+		}
+	}
+
+	ensure.DeepEqual(t, all, map[string]float64{
+		"foo.avg":      1.5,
+		"foo.sum":      3.0,
+		"foo.time":     5.0,
+		"foo.time.p50": 5.0,
+		"foo.time.p95": 10.0,
+		"foo.time.p99": 10.0,
+	})
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/license
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/license
@@ -1,0 +1,30 @@
+BSD License
+
+For stats software
+
+Copyright (c) 2015, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/patents
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/patents
@@ -1,0 +1,33 @@
+Additional Grant of Patent Rights Version 2
+
+"Software" means the stats software distributed by Facebook, Inc.
+
+Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
+("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook’s rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/readme.md
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/readme.md
@@ -1,0 +1,4 @@
+stats [![Build Status](https://secure.travis-ci.org/facebookgo/stats.png)](https://travis-ci.org/facebookgo/stats)
+=====
+
+Documentation: https://godoc.org/github.com/facebookgo/stats

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/stats.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/stats.go
@@ -1,0 +1,166 @@
+// Package stats defines a lightweight interface for collecting statistics. It
+// doesn't provide an implementation, just the shared interface.
+package stats
+
+// Client provides methods to collection statistics.
+type Client interface {
+	// BumpAvg bumps the average for the given key.
+	BumpAvg(key string, val float64)
+
+	// BumpSum bumps the sum for the given key.
+	BumpSum(key string, val float64)
+
+	// BumpHistogram bumps the histogram for the given key.
+	BumpHistogram(key string, val float64)
+
+	// BumpTime is a special version of BumpHistogram which is specialized for
+	// timers. Calling it starts the timer, and it returns a value on which End()
+	// can be called to indicate finishing the timer. A convenient way of
+	// recording the duration of a function is calling it like such at the top of
+	// the function:
+	//
+	//     defer s.BumpTime("my.function").End()
+	BumpTime(key string) interface {
+		End()
+	}
+}
+
+// PrefixClient adds multiple keys for the same value, with each prefix
+// added to the key and calls the underlying client.
+func PrefixClient(prefixes []string, client Client) Client {
+	return &prefixClient{
+		Prefixes: prefixes,
+		Client:   client,
+	}
+}
+
+type prefixClient struct {
+	Prefixes []string
+	Client   Client
+}
+
+func (p *prefixClient) BumpAvg(key string, val float64) {
+	for _, prefix := range p.Prefixes {
+		p.Client.BumpAvg(prefix+key, val)
+	}
+}
+
+func (p *prefixClient) BumpSum(key string, val float64) {
+	for _, prefix := range p.Prefixes {
+		p.Client.BumpSum(prefix+key, val)
+	}
+}
+
+func (p *prefixClient) BumpHistogram(key string, val float64) {
+	for _, prefix := range p.Prefixes {
+		p.Client.BumpHistogram(prefix+key, val)
+	}
+}
+
+func (p *prefixClient) BumpTime(key string) interface {
+	End()
+} {
+	var m multiEnder
+	for _, prefix := range p.Prefixes {
+		m = append(m, p.Client.BumpTime(prefix+key))
+	}
+	return m
+}
+
+// multiEnder combines many enders together.
+type multiEnder []interface {
+	End()
+}
+
+func (m multiEnder) End() {
+	for _, e := range m {
+		e.End()
+	}
+}
+
+// HookClient is useful for testing. It provides optional hooks for each
+// expected method in the interface, which if provided will be called. If a
+// hook is not provided, it will be ignored.
+type HookClient struct {
+	BumpAvgHook       func(key string, val float64)
+	BumpSumHook       func(key string, val float64)
+	BumpHistogramHook func(key string, val float64)
+	BumpTimeHook      func(key string) interface {
+		End()
+	}
+}
+
+// BumpAvg will call BumpAvgHook if defined.
+func (c *HookClient) BumpAvg(key string, val float64) {
+	if c.BumpAvgHook != nil {
+		c.BumpAvgHook(key, val)
+	}
+}
+
+// BumpSum will call BumpSumHook if defined.
+func (c *HookClient) BumpSum(key string, val float64) {
+	if c.BumpSumHook != nil {
+		c.BumpSumHook(key, val)
+	}
+}
+
+// BumpHistogram will call BumpHistogramHook if defined.
+func (c *HookClient) BumpHistogram(key string, val float64) {
+	if c.BumpHistogramHook != nil {
+		c.BumpHistogramHook(key, val)
+	}
+}
+
+// BumpTime will call BumpTimeHook if defined.
+func (c *HookClient) BumpTime(key string) interface {
+	End()
+} {
+	if c.BumpTimeHook != nil {
+		return c.BumpTimeHook(key)
+	}
+	return NoOpEnd
+}
+
+type noOpEnd struct{}
+
+func (n noOpEnd) End() {}
+
+// NoOpEnd provides a dummy value for use in tests as valid return value for
+// BumpTime().
+var NoOpEnd = noOpEnd{}
+
+// BumpAvg calls BumpAvg on the Client if it isn't nil. This is useful when a
+// component has an optional stats.Client.
+func BumpAvg(c Client, key string, val float64) {
+	if c != nil {
+		c.BumpAvg(key, val)
+	}
+}
+
+// BumpSum calls BumpSum on the Client if it isn't nil. This is useful when a
+// component has an optional stats.Client.
+func BumpSum(c Client, key string, val float64) {
+	if c != nil {
+		c.BumpSum(key, val)
+	}
+}
+
+// BumpHistogram calls BumpHistogram on the Client if it isn't nil. This is
+// useful when a component has an optional stats.Client.
+func BumpHistogram(c Client, key string, val float64) {
+	if c != nil {
+		c.BumpHistogram(key, val)
+	}
+}
+
+// BumpTime calls BumpTime on the Client if it isn't nil. If the Client is nil
+// it still returns a valid return value which will be a no-op. This is useful
+// when a component has an optional stats.Client.
+func BumpTime(c Client, key string) interface {
+	End()
+} {
+	if c != nil {
+		return c.BumpTime(key)
+	}
+	return NoOpEnd
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/stats_test.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/stats_test.go
@@ -1,0 +1,77 @@
+package stats_test
+
+import (
+	"testing"
+
+	"github.com/facebookgo/ensure"
+	"github.com/facebookgo/stats"
+)
+
+// Ensure calling End works even when a BumpTimeHook isn't provided.
+func TestHookClientBumpTime(t *testing.T) {
+	(&stats.HookClient{}).BumpTime("foo").End()
+}
+
+func TestPrefixClient(t *testing.T) {
+	const (
+		prefix1      = "prefix1"
+		prefix2      = "prefix2"
+		avgKey       = "avg"
+		avgVal       = float64(1)
+		sumKey       = "sum"
+		sumVal       = float64(2)
+		histogramKey = "histogram"
+		histogramVal = float64(3)
+		timeKey      = "time"
+	)
+
+	var keys []string
+	hc := &stats.HookClient{
+		BumpAvgHook: func(key string, val float64) {
+			keys = append(keys, key)
+			ensure.DeepEqual(t, val, avgVal)
+		},
+		BumpSumHook: func(key string, val float64) {
+			keys = append(keys, key)
+			ensure.DeepEqual(t, val, sumVal)
+		},
+		BumpHistogramHook: func(key string, val float64) {
+			keys = append(keys, key)
+			ensure.DeepEqual(t, val, histogramVal)
+		},
+		BumpTimeHook: func(key string) interface {
+			End()
+		} {
+			return multiEnderTest{
+				EndHook: func() {
+					keys = append(keys, key)
+				},
+			}
+		},
+	}
+
+	pc := stats.PrefixClient([]string{prefix1, prefix2}, hc)
+	pc.BumpAvg(avgKey, avgVal)
+	pc.BumpSum(sumKey, sumVal)
+	pc.BumpHistogram(histogramKey, histogramVal)
+	pc.BumpTime(timeKey).End()
+
+	ensure.SameElements(t, keys, []string{
+		prefix1 + avgKey,
+		prefix1 + sumKey,
+		prefix1 + histogramKey,
+		prefix1 + timeKey,
+		prefix2 + avgKey,
+		prefix2 + sumKey,
+		prefix2 + histogramKey,
+		prefix2 + timeKey,
+	})
+}
+
+type multiEnderTest struct {
+	EndHook func()
+}
+
+func (e multiEnderTest) End() {
+	e.EndHook()
+}

--- a/Godeps/_workspace/src/github.com/facebookgo/stats/stopper.go
+++ b/Godeps/_workspace/src/github.com/facebookgo/stats/stopper.go
@@ -1,0 +1,17 @@
+package stats
+
+import "time"
+
+// Stopper calls Client.BumpSum and Client.BumpHistogram when End'ed
+type Stopper struct {
+	Key    string
+	Start  time.Time
+	Client Client
+}
+
+// End the Stopper
+func (s *Stopper) End() {
+	since := time.Since(s.Start).Seconds() * 1000.0
+	s.Client.BumpSum(s.Key+".total", since)
+	s.Client.BumpHistogram(s.Key, since)
+}

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ $(TARGETS): ./bin
 	$(GOCMD) build -ldflags "-X github.com/ndlib/bendo/server.Version=$(VERSION)" \
 		-o ./bin/$(notdir $@) ./$@
 
+.PHONY: $(TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ TARGETS:=$(wildcard ./cmd/*)
 GOCMD:=$(if $(shell which godep),godep go,go)
 VERSION:=$(shell git describe --always)
 PACKAGES:=$(shell go list ./... | grep -v /vendor/)
+GOPATH:=$(realpath ./Godeps/_workspace/):$(GOPATH)
 
 all: $(TARGETS)
 
 test:
-	$(GOCMD) test $(PACKAGES)
+	$(GOCMD) test -v $(PACKAGES)
 
 clean:
 	rm -rf ./bin

--- a/server/fixity.go
+++ b/server/fixity.go
@@ -34,12 +34,22 @@ type FixityDB interface {
 	LookupCheck(id string) (time.Time, error)
 }
 
-// StartFixity starts a background goroutine to check item fixity.
+// StartFixity starts the background goroutines to check item fixity. It
+// returns immediately and does not block.
 func (s *RESTServer) StartFixity() {
 	go s.fixity()
+
+	// should scanfixity run periodically? or only at startup?
+	// this will keep running it in a loop with 24 hour rest in between.
+	go func() {
+		for {
+			s.scanfixity()
+			time.Sleep(24 * time.Hour)
+		}
+	}()
 }
 
-var (
+const (
 	// by default schedule the next fixity in 273 days (~9 months)
 	// this duration is completely arbitrary.
 	nextFixityDuration = 273 * 24 * time.Hour

--- a/server/routes.go
+++ b/server/routes.go
@@ -188,7 +188,6 @@ func (s *RESTServer) Run() error {
 	}
 	log.Println("Listening on", s.PortNumber)
 
-	var err error
 	h := httpdown.HTTP{}
 	s.server, err = h.ListenAndServe(&http.Server{
 		Addr:    ":" + s.PortNumber,

--- a/server/routes.go
+++ b/server/routes.go
@@ -9,8 +9,8 @@ import (
 	_ "net/http/pprof" // for pprof server
 	"os"
 	"path/filepath"
-	"time"
 
+	"github.com/facebookgo/httpdown"
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/ndlib/bendo/blobcache"
@@ -18,6 +18,7 @@ import (
 	"github.com/ndlib/bendo/items"
 	"github.com/ndlib/bendo/store"
 	"github.com/ndlib/bendo/transaction"
+	"github.com/ndlib/bendo/util"
 )
 
 // RESTServer holds the configuration for a Bendo REST API server.
@@ -76,11 +77,17 @@ type RESTServer struct {
 
 	// Fixity stores the records tracking past and future fixity checks.
 	Fixity FixityDB
+
+	server httpdown.Server // used to close our listening socket
+	txgate *util.Gate      // limits number of concurrent transactions
 }
+
+// the number of active commits onto tape we allow at a given time
+const MaxConcurrentCommits = 2
 
 // Run initializes and starts all the goroutines used by the server. It then
 // blocks listening for and handling http requests.
-func (s *RESTServer) Run() {
+func (s *RESTServer) Run() error {
 	log.Println("==========")
 	log.Printf("Starting Bendo Server version %s", Version)
 	log.Printf("CacheDir = %s", s.CacheDir)
@@ -122,14 +129,6 @@ func (s *RESTServer) Run() {
 		s.Fixity = db
 	}
 	s.StartFixity()
-	// should scanfixity run periodically? or only at startup?
-	// this will keep running it in a loop with 24 hour rest in between.
-	go func() {
-		for {
-			s.scanfixity()
-			time.Sleep(24 * time.Hour)
-		}
-	}()
 
 	// init blobcache
 	if s.Cache == nil {
@@ -177,6 +176,7 @@ func (s *RESTServer) Run() {
 	s.FileStore.Load()
 
 	log.Println("Starting pending transactions")
+	s.txgate = util.NewGate(MaxConcurrentCommits)
 	go s.initCommitQueue()
 
 	// for pprof
@@ -187,14 +187,39 @@ func (s *RESTServer) Run() {
 		}()
 	}
 	log.Println("Listening on", s.PortNumber)
-	http.ListenAndServe(":"+s.PortNumber, s.addRoutes())
+
+	var err error
+	h := httpdown.HTTP{}
+	s.server, err = h.ListenAndServe(&http.Server{
+		Addr:    ":" + s.PortNumber,
+		Handler: s.addRoutes(),
+	})
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	return s.server.Wait()
+}
+
+// Stop will stop the server and return when all the server goroutines have
+// exited and the socked closed.
+func (s *RESTServer) Stop() error {
+	// first shutdown the transaction writing.
+	// We don't stop the fixity process. Should we?
+	s.txgate.Stop() // release and wait for any in progress transactions
+
+	// then shutdown all the HTTP connections
+	return s.server.Stop()
 }
 
 func (s *RESTServer) initCommitQueue() {
 	// for each commit, pass to processCommit, and let it sort things out
 	for _, tid := range s.TxStore.List() {
 		tx := s.TxStore.Lookup(tid)
-		if tx.Status == transaction.StatusWaiting || tx.Status == transaction.StatusIngest {
+		if tx.Status == transaction.StatusWaiting ||
+			tx.Status == transaction.StatusChecking ||
+			tx.Status == transaction.StatusIngest {
+
 			tx.SetStatus(transaction.StatusWaiting)
 			go s.processCommit(tx)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ndlib/bendo/items"
 	"github.com/ndlib/bendo/store"
 	"github.com/ndlib/bendo/transaction"
+	"github.com/ndlib/bendo/util"
 )
 
 func TestTransaction1(t *testing.T) {
@@ -232,10 +233,6 @@ func checkRoute(t *testing.T, verb, route string, expstatus int) *http.Response 
 var testServer *httptest.Server
 
 func init() {
-	//err := openDatabase("memory")
-	//if err != nil {
-	//	log.Println(err.Error())
-	//}
 	server := &RESTServer{
 		Validator: NewNobodyValidator(),
 		Items:     items.New(store.NewMemory()),
@@ -243,6 +240,7 @@ func init() {
 		FileStore: fragment.New(store.NewMemory()),
 		Cache:     blobcache.EmptyCache{},
 	}
+	server.txgate = util.NewGate(MaxConcurrentCommits)
 	server.TxStore.Load()
 	testServer = httptest.NewServer(server.addRoutes())
 }

--- a/util/gate.go
+++ b/util/gate.go
@@ -1,26 +1,53 @@
 package util
 
+import (
+	"sync"
+)
+
 // A Gate limits concurrency. Every gate has a maximum number
 // number of goroutines to allow through at a time. Goroutines enter the gate
-// by calling Enter(), and signal that they are done by calling Leave()
-type Gate chan struct{}
-
-// NewGate returns a Gate which accepts at most n entries at a time.
-func NewGate(n int) Gate {
-	return Gate(make(chan struct{}, n))
+// by calling Enter(), and signal that they are done by calling Leave().
+// Enter() blocks until either there is room for the calling goroutine to enter,
+// or Stop() is called on the Gate.
+type Gate struct {
+	c  chan struct{}
+	wg sync.WaitGroup
 }
 
-// Enter is called at the beginning of the section to be protected by
-// the gate, and will block the calling goroutine until there are less than
-// n goroutines inside.
-// It is safe to call this from multiple goroutines.
-func (g Gate) Enter() {
-	g <- struct{}{}
+// NewGate returns a Gate which accepts at most n entries at a time.
+func NewGate(n int) *Gate {
+	return &Gate{c: make(chan struct{}, n)}
+}
+
+// Enter is called at the beginning of the section to be protected by the gate,
+// and will block the calling goroutine until there are less than n goroutines
+// inside, or Stop() is called on the Gate. It is safe to call this from
+// multiple goroutines. Enter returns false if the return is due to Stop being
+// called and true otherwise.
+func (g *Gate) Enter() bool {
+	var ok = true
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	g.c <- struct{}{}
+	g.wg.Add(1)
+	return ok
 }
 
 // Leave marks a goroutine outside the critical section. It is important to
 // balance each call to Enter with a call to Leave. Enter and Leave do not need
 // to be called from the same goroutine, necessarily.
-func (g Gate) Leave() {
-	<-g
+func (g *Gate) Leave() {
+	g.wg.Done()
+	<-g.c
+}
+
+// Stop will cause all goroutines waiting on Enter() for this gate to exit with
+// a false return value. Stop will then block until all the goroutines
+// currently inside the Gate call Leave.
+func (g *Gate) Stop() {
+	close(g.c)
+	g.wg.Wait()
 }

--- a/util/gate_test.go
+++ b/util/gate_test.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGateMaximum(t *testing.T) {
+	// create 10 goroutines trying to enter a gate that can only hold 5
+	g := NewGate(5)
+	var nenter, nerr int64
+	for i := 0; i < 10; i++ {
+		go func() {
+			ok := g.Enter()
+			if ok {
+				atomic.AddInt64(&nenter, 1)
+			} else {
+				atomic.AddInt64(&nerr, 1)
+			}
+		}()
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	// there should be 5 enters
+	if nenter != 5 {
+		t.Errorf("Received %d enters, expected %d", nenter, 5)
+	}
+	if nerr != 0 {
+		t.Errorf("Received %d errors, expected %d", nerr, 0)
+	}
+
+	// call leave a few times and see what happens
+	g.Leave()
+	g.Leave()
+	time.Sleep(10 * time.Millisecond)
+
+	if nenter != 7 {
+		t.Errorf("Received %d enters, expected %d", nenter, 7)
+	}
+	if nerr != 0 {
+		t.Errorf("Received %d errors, expected %d", nerr, 0)
+	}
+
+	// need to balance out the 5 enters which have made it through
+	// the gate. But need to do it AFTER we call Stop, so the enters
+	// still waiting exit in error.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		for i := 0; i < 5; i++ {
+			g.Leave()
+		}
+	}()
+	g.Stop()
+
+	if nenter != 7 {
+		t.Errorf("Received %d enters, expected %d", nenter, 7)
+	}
+	if nerr != 3 {
+		t.Errorf("Received %d errors, expected %d", nerr, 3)
+	}
+}


### PR DESCRIPTION
We use the httpdown package to provide a way to close the http socket
and exit when all the pending requests have finished. The critical
component in the shutdown, the transaction writting goroutines, are
handled by changing the gate code to track the goroutines inside it and
to release goroutines waiting to enter it. Finally, we add a signal
handler to the bendo server application.

* move transaction gate into the server struct
* move fixity scanner into the fixity file
* fix makefile rules to always build the targets
* add gate test code

Issue #36