### PR TITLE
Set the bag tags when saving bundles

### DIFF
--- a/items/bundler.go
+++ b/items/bundler.go
@@ -59,6 +59,10 @@ func (bw *BundleWriter) Next() error {
 	if err != nil {
 		return err
 	}
+	bw.zw.SetTag("Bendo-Identifier", bw.item.ID)
+	bw.zw.SetTag("Bendo-Bundle-Sequence", fmt.Sprintf("%d", bw.n))
+	bw.zw.SetTag("External-Identifier",
+		strings.TrimSuffix(sugar(bw.item.ID, bw.n), ".zip"))
 	bw.n++
 	bw.size = 0
 	return nil


### PR DESCRIPTION
It sets the tags

 * 'Bendo-Identifier'
 * 'Bendo-Bundle-Sequence'
 * 'External-Identifier'

It does not set an item schema version since the bundle is the wrong
level of abstraction. The item schema version should be tracked in the
JSON structure itself.

issue #17