### PR TITLE
Support the @blob/nnn syntax

### DIFF
--- a/items/item_test.go
+++ b/items/item_test.go
@@ -1,0 +1,47 @@
+package items
+
+import (
+	"testing"
+)
+
+func TestBlobByExtendedSlot(t *testing.T) {
+	m := Item{
+		Blobs: []*Blob{&Blob{}, &Blob{}, &Blob{}, &Blob{}, &Blob{}},
+		Versions: []*Version{
+			&Version{
+				ID:    1,
+				Slots: map[string]BlobID{"a": 1, "b": 2, "c": 3},
+			},
+			&Version{
+				ID:    2,
+				Slots: map[string]BlobID{"b": 2, "c": 4, "d": 5},
+			},
+		},
+	}
+	table := []struct {
+		input  string
+		output BlobID
+	}{
+		{"a", 0},
+		{"@1/a", 1},
+		{"b", 2},
+		{"@1/b", 2},
+		{"c", 4},
+		{"@1/d", 0},
+		{"@blob/4", 4},
+		{"@blob/04", 4}, // octal?
+		{"@blob/0x4", 0},
+		{"@blob/", 0},
+	}
+
+	for _, tab := range table {
+		r := m.BlobByExtendedSlot(tab.input)
+		if r != tab.output {
+			t.Errorf("Input: %s. Received %d, expected %d",
+				tab.input,
+				r,
+				tab.output)
+		}
+	}
+
+}

--- a/server/item.go
+++ b/server/item.go
@@ -44,7 +44,7 @@ func (s *RESTServer) SlotHandler(w http.ResponseWriter, r *http.Request, ps http
 		fmt.Fprintf(w, "Invalid Version")
 		return
 	}
-	w.Header().Set("Location", fmt.Sprintf("/blob/%s/%d", id, bid))
+	w.Header().Set("Location", fmt.Sprintf("/items/%s/@blob/%d", id, bid))
 	s.getblob(w, r, id, items.BlobID(bid))
 }
 


### PR DESCRIPTION
This is to allow the `/item/xxxx/@blob/45` syntax. It is intended to
replace the `/blob/*` routes eventually.