### PR TITLE
Add transaction cleaner

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -178,6 +178,9 @@ func (s *RESTServer) Run() error {
 	log.Println("Scanning Upload Queue")
 	s.FileStore.Load()
 
+	log.Println("Starting Transaction Cleaner")
+	s.StartTxCleaner()
+
 	log.Println("Starting pending transactions")
 	s.txgate = util.NewGate(MaxConcurrentCommits)
 	go s.initCommitQueue()

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"errors"
+	"log"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -18,7 +19,7 @@ import (
 // from the underlying store.
 func New(s store.Store) *Store {
 	return &Store{
-		TxStore: fragment.NewJSON(store.NewWithPrefix(s, "tx:")),
+		TxStore: fragment.NewJSON(s),
 		txs:     make(map[string]*T),
 	}
 }
@@ -38,6 +39,7 @@ func (r *Store) Load() error {
 		tx := new(T)
 		err := r.TxStore.Open(key, tx)
 		if err != nil {
+			log.Printf("TxLoad %s: %s\n", key, err.Error())
 			continue
 		}
 		tx.txstore = &r.TxStore
@@ -167,11 +169,6 @@ const (
 )
 
 //go:generate stringer -type=Status
-
-// MarshalJSON lets statuses be exported as a string when json encoding.
-func (s Status) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + s.String() + `"`), nil
-}
 
 // AddCommandList changes the command list to process when committing this
 // transaction to the one given.


### PR DESCRIPTION
It will run twice a day and remove any finished transactions.

* Change transaction serialization to fix transaction loading bug
(prevously the transaction state was saved as a string. but there was no
code to unserialize the string. Change to save the state as an integer)
* Delete successful transactions after 24 hours
* Delete unsuccessful transactions after 1 week
* Delete orphaned files after 2 weeks
* Change transaction html template to hyperlink uploaded files
* Remove tx: prefix for transaction stores. Since we are putting
transactions into their own subdirectory of the cache dir, prefixing the
keys with a "tx:" is not needed anymore.

Issue #39