### PR TITLE
Add Content-Length header to content downloads

### DIFF
--- a/cmd/butil/main.go
+++ b/cmd/butil/main.go
@@ -69,7 +69,7 @@ func main() {
 func doblob(r *items.Store, id, blob string) {
 	bid, _ := strconv.Atoi(blob)
 
-	rc, err := r.Blob(id, items.BlobID(bid))
+	rc, _, err := r.Blob(id, items.BlobID(bid))
 	if err != nil {
 		fmt.Printf("%s / %d: Error %s\n", id, bid, err.Error())
 	} else {

--- a/items/writer_test.go
+++ b/items/writer_test.go
@@ -176,7 +176,7 @@ func TestDeleteBlob(t *testing.T) {
 	}
 
 	// is the 10th blob readable?
-	rc, err := s.Blob("abc", 10)
+	rc, _, err := s.Blob("abc", 10)
 	if err != nil {
 		t.Errorf("Received %s, expected nil", err.Error())
 	}
@@ -188,7 +188,7 @@ func TestDeleteBlob(t *testing.T) {
 	}
 
 	// is the 1st blob deleted?
-	_, err = s.Blob("abc", 1)
+	_, _, err = s.Blob("abc", 1)
 	if err == nil {
 		t.Errorf("Received nil, expected error")
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -239,6 +239,8 @@ func (s *RESTServer) addRoutes() http.Handler {
 		role    Role // RoleUnknown means no API key is needed to access
 		handler httprouter.Handle
 	}{
+		// the /blob/* routes can be removed. they are functionally the
+		// same as /item/@blob/*
 		{"GET", "/blob/:id/:bid", RoleRead, s.BlobHandler},
 		{"HEAD", "/blob/:id/:bid", RoleRead, s.BlobHandler},
 		{"GET", "/item/:id/*slot", RoleUnknown, s.SlotHandler},


### PR DESCRIPTION
Disadis relies on this information to support range requests. Whenever
we move range requests into bendo proper, will will also need the
length.

issue #96 , #21