### PR TITLE
Log which database we are using.

### DIFF
--- a/puppet/modules/lib_bendo_server/templates/bendo.exec.erb
+++ b/puppet/modules/lib_bendo_server/templates/bendo.exec.erb
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 exec 2>&1
-exec /sbin/chpst -u app <%= @bendo_root %>/gocode/bin/bendo -storage <%= @bendo_storage_dir %> --cache-dir <%= @bendo_cache_dir %> --cache-size <%= @bendo_cache_size %> --mysql <%= @bendo_mysql_user %>:<%= @bendo_mysql_password %>@tcp\(<%= @bendo_mysql_server %>:3306\)/<%= @bendo_mysql_db %> -user-tokens <%= @bendo_root %>/tokens
+exec /sbin/chpst -u app <%= @bendo_root %>/gocode/bin/bendo \
+    --storage <%= @bendo_storage_dir %> \
+    --cache-dir <%= @bendo_cache_dir %> \
+    --cache-size <%= @bendo_cache_size %> \
+    --mysql '<%= @bendo_mysql_user %>:<%= @bendo_mysql_password %>@tcp(<%= @bendo_mysql_server %>:3306)/<%= @bendo_mysql_db %>' \
+    --user-tokens <%= @bendo_root %>/tokens

--- a/server/routes.go
+++ b/server/routes.go
@@ -110,6 +110,7 @@ func (s *RESTServer) Run() error {
 	}
 	var err error
 	if s.MySQL != "" {
+		log.Printf("Using MySQL")
 		db, err = NewMysqlCache(s.MySQL)
 	} else {
 		var path string
@@ -118,6 +119,7 @@ func (s *RESTServer) Run() error {
 		} else {
 			path = "memory"
 		}
+		log.Printf("Using internal database at %s", path)
 		db, err = NewQlCache(path)
 	}
 	if db == nil || err != nil {


### PR DESCRIPTION
Also reformat the runit run script so the command line options are
clearer. The problem with bendo not connecting to mysql on the staging
machine was was the run script on the server was missing the
`--cache-size` option, so its parameter was interpreted as the end of the
options and then the `--mysql` option was not parsed.