### PR TITLE
Add expvar statistics

### DIFF
--- a/server/fixity.go
+++ b/server/fixity.go
@@ -97,9 +97,11 @@ func (s *RESTServer) fixity() {
 		d := time.Now().Sub(starttime)
 		log.Println("Fixity for", id, "is", status, "duration = ", d)
 		err = s.Fixity.UpdateFixity(id, status, notes)
+
 		xFixityItemsChecked.Add(1)
 		xFixityBytesChecked.Add(nbytes)
 		xFixityDuration.Add(d.Seconds())
+
 		// schedule the next check unless one is already scheduled
 		when, _ := s.Fixity.LookupCheck(id)
 		if when.IsZero() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -182,7 +182,7 @@ func (s *RESTServer) Run() error {
 	s.FileStore.Load()
 
 	log.Println("Starting Transaction Cleaner")
-	s.StartTxCleaner()
+	go s.TxCleaner()
 
 	log.Println("Starting pending transactions")
 	s.txgate = util.NewGate(MaxConcurrentCommits)

--- a/server/routes.go
+++ b/server/routes.go
@@ -279,7 +279,7 @@ func (s *RESTServer) addRoutes() http.Handler {
 		// other
 		{"GET", "/", RoleUnknown, WelcomeHandler},
 		{"GET", "/stats", RoleUnknown, NotImplementedHandler},
-		{"GET", "/debug/vars", RoleUnknown, VarHandler},
+		{"GET", "/debug/vars", RoleUnknown, VarHandler}, // standard route for expvars data
 	}
 
 	r := httprouter.New()

--- a/server/routes.go
+++ b/server/routes.go
@@ -265,12 +265,6 @@ func (s *RESTServer) addRoutes() http.Handler {
 		{"GET", "/upload/:fileid/metadata", RoleMDOnly, s.GetFileInfoHandler},
 		{"PUT", "/upload/:fileid/metadata", RoleWrite, s.SetFileInfoHandler},
 
-		// fixity reporting
-		{"GET", "/fixity", RoleRead, NotImplementedHandler},
-		{"GET", "/fixity/errors", RoleRead, NotImplementedHandler},
-		{"GET", "/fixity/item/:itemid", RoleRead, NotImplementedHandler},
-		{"POST", "/fixity/:itemid", RoleWrite, NotImplementedHandler},
-
 		// the read only bundle stuff
 		{"GET", "/bundle/list/:prefix", RoleRead, s.BundleListPrefixHandler},
 		{"GET", "/bundle/list/", RoleRead, s.BundleListHandler},
@@ -293,7 +287,7 @@ func (s *RESTServer) addRoutes() http.Handler {
 
 // General route handlers and convinence functions
 
-// VarHandler adapts the expvar default handler to our router.
+// VarHandler adapts the expvar default handler to the httprouter three parameter handler.
 func VarHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// this code is taken from the stdlib expvar package.
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -174,7 +174,7 @@ func (s *RESTServer) TxCleaner() {
 // transactionCleaner will go through all finished transactions (i.e. in either
 // the error or successful states) which are old, and delete them and any
 // uploaded files they reference. Successful transactions older than a day are
-// removed, and Failed transactions older than a week are removed.
+// removed, and failed transactions older than a week are removed.
 func (s *RESTServer) transactionCleaner() error {
 	// these time limits are completely arbitrary
 	cutoffSuccess := time.Now().Add(-24 * time.Hour)

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"html/template"
 	"log"
@@ -142,26 +143,32 @@ func (s *RESTServer) processCommit(tx *transaction.T) {
 	}
 	duration := time.Now().Sub(start)
 	log.Printf("Finish transaction %s on %s (%s)", tx.ID, tx.ItemID, duration.String())
+
+	xTransactionTime.Add(duration.Seconds())
+	xTransactionCount.Add(1)
 }
 
-// StartTxCleaner will spawn a background goroutine to remove old transactions.
-// That means any finished transactions which are older than a few days. Both
-// the transaction and any uploaded files referenced by the transaction are
-// deleted.
-func (s *RESTServer) StartTxCleaner() {
-	go func() {
-		for {
-			err := s.transactionCleaner()
-			if err == nil {
-				err = s.fileCleaner()
-			}
-			if err != nil {
-				log.Println("TxCleaner:", err)
-			}
-			// wait for a while before beginning again
-			time.Sleep(12 * time.Hour) // duration is arbitrary
+var (
+	xTransactionCount = expvar.NewInt("tx.count")
+	xTransactionTime  = expvar.NewFloat("tx.seconds")
+)
+
+// TxCleaner will loop forever removing old transactions and old orphened
+// uploaded files. That means any finished transactions which are older than a
+// few days. Both the transaction and any uploaded files referenced by the
+// transaction are deleted. This function will never return.
+func (s *RESTServer) TxCleaner() {
+	for {
+		err := s.transactionCleaner()
+		if err == nil {
+			err = s.fileCleaner()
 		}
-	}()
+		if err != nil {
+			log.Println("TxCleaner:", err)
+		}
+		// wait for a while before beginning again
+		time.Sleep(12 * time.Hour) // duration is arbitrary
+	}
 }
 
 // transactionCleaner will go through all finished transactions (i.e. in either


### PR DESCRIPTION
Simple-minded stats reporting. It uses the expvar package. I kept the usual default expvar route `/debug/vars/`.

Not implemented is any kind of storage statistics, such as total amount stored in bytes or total number of items. I mainly wanted to get the completed work merged sooner than later.

issue #43