### PR TITLE
Adding a script to symlink the bendo executables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,16 @@ bstress
 butil
 ```
 
+These executables need to be added to your `$PATH`. The simplest way to do that is to run the linking script:
+
+```console
+./link.sh
+```
+
+This symlinks the executables into `$GOPATH/bin`.
+
+> `$GOPATH/bin` is already added to your `$PATH` by [DLT dotfiles](https://github.com/ndlib/dlt-dotfiles)
+
 ## Running Bendo
 There are also several setup steps in order to _run_ Bendo.
 
@@ -89,4 +99,4 @@ cd ~/goapps/bendo
 bendo -config-file development.config
 ```
 
-> The `bendo` command is added to your `$PATH` by [DLT-dotfiles](https://github.com/ndlib/dlt-dotfiles). If you need to call it directly use `$GOPATH/src/github.com/ndlib/bendo/bin/bendo`.
+> The `bendo` command is added to your `$PATH` by [DLT-dotfiles](https://github.com/ndlib/dlt-dotfiles). If you need to call it directly use `$GOPATH/bin/bendo`.

--- a/link.sh
+++ b/link.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Link the binaries built by the Makefile to $GOPATH/bin
+
+echo "Checking to see if \$GOPATH is set"
+"${GOPATH:?GOPATH must be non-empty}"
+
+echo "Looking for $GOPATH/bin"
+if [ -d "$GOPATH/bin" ]; then
+  echo "$GOPATH/bin directory exists"
+else
+  echo "Creating $GOPATH/bin directory"
+  mkdir -p "$GOPATH/bin"
+fi
+
+echo "Linking binaries"
+ln -s $GOPATH/src/github.com/ndlib/bendo/bin/* "$GOPATH/bin"


### PR DESCRIPTION
Small utility script for linking the compiled binaries into a standard path.

This helps simplify https://github.com/ndlib/dlt-dotfiles/pull/6