### PR TITLE
Use chan for transactions

### DIFF
--- a/bagit/writer.go
+++ b/bagit/writer.go
@@ -150,7 +150,6 @@ func (w *Writer) manifest(istag bool, name string, hash func(Checksum) []byte) {
 			} else {
 				mname = "manifest-" + name + ".txt"
 			}
-			// TODO(dbrower): check for error?
 			out, _ = w.create(mname)
 		}
 		// The 2 spaces is to be identical to the GNU md5sum output.

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -98,9 +98,7 @@ func (s *RESTServer) NewTxHandler(w http.ResponseWriter, r *http.Request, ps htt
 		return
 	}
 	tx.SetStatus(transaction.StatusWaiting)
-	go func() {
-		s.txqueue <- tx.ID
-	}()
+	s.txqueue <- tx.ID
 	w.WriteHeader(202)
 }
 


### PR DESCRIPTION
This PR is open to some comment. Before each transaction waiting had its own goroutine and used a _gate_ construct to make sure only so many were actually working at any time. This PR changes that so that there is a fixed number of transaction worker goroutines, and they pull the transaction jobs from an in-memory queue. Everything is also synced to disk, so the jobs are persistent between restarts.

I feel this way of doing it---i.e. fixed number of worker threads and a queue---is clearer than having an arbitrary number of waiting goroutines and a gate mechanism to limit concurrency. I'm open to feedback.