### PR TITLE
Fix bclient get performance issue

### DIFF
--- a/fileutil/filelist.go
+++ b/fileutil/filelist.go
@@ -101,9 +101,9 @@ func (f *FileList) BuildListFromJSON(json *jason.Object) {
 		versionID, _ := version.GetInt64("ID")
 		slotMap, _ := version.GetObject("Slots")
 
-		for key, _ := range slotMap.Map() {
+		for key, value := range slotMap.Map() {
 
-			blobID, _ := slotMap.GetInt64(key)
+			blobID, _ := value.Int64()
 			md5Sum, _ := blobArray[blobID-1].GetString("MD5")
 			DecodedMD5, _ := base64.StdEncoding.DecodeString(md5Sum)
 


### PR DESCRIPTION
Change decoding the item JSON response from the server to use the value
provided by the jason iterator. This improves the get performance by 15
times in my measurments.

This commit also includes the boilerplate I added to enable profiling in
bclient. Start cpu profiling by using the `-cpuprofile` command line
option.

The test command I used was

    time ./bin/bclient -cpuprofile ,,slow.pprof -server
      http://bendo-prod-vm.example.org:14000 get kp78gf0997k
      France-Paris-church-S-Louis.jpg

and then to view the profile

    go tool pprof ./bin/bclient ,,slot.pprof