### PR TITLE
Add mime type server

### DIFF
--- a/fragment/fragment.go
+++ b/fragment/fragment.go
@@ -71,6 +71,9 @@ type FileEntry interface {
 	// its blocks).
 	SetSHA256(hash []byte)
 
+	// Set the mime-type of this file.
+	SetMimeType(mimetype string)
+
 	// Sets an opaque metadata blob which can be assigned to each file.
 	SetExtra(extra string)
 

--- a/fragment/fragment.go
+++ b/fragment/fragment.go
@@ -90,6 +90,7 @@ type Stat struct {
 	Labels     []string
 	MD5        []byte // expected hash for entire file
 	SHA256     []byte // expected hash for entire file
+	MimeType   string
 	Extra      string // arbitrary user defined content
 }
 
@@ -107,6 +108,7 @@ type file struct {
 	Creator  string       // the "user" (aka API key) who created this file
 	MD5      []byte       // expected hash for entire file
 	SHA256   []byte       // expected hash for entire file
+	MimeType string       // the mime type of the file
 	Extra    string       // arbitrary user defined content
 }
 
@@ -320,6 +322,7 @@ func (f *file) Stat() Stat {
 		Labels:     f.Labels[:],
 		MD5:        f.MD5[:],
 		SHA256:     f.SHA256[:],
+		MimeType:   f.MimeType,
 		Extra:      f.Extra,
 	}
 }
@@ -506,6 +509,13 @@ func (f *file) SetSHA256(hash []byte) {
 	f.m.Lock()
 	defer f.m.Unlock()
 	f.SHA256 = hash[:]
+	f.save()
+}
+
+func (f *file) SetMimeType(mimetype string) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	f.MimeType = mimetype
 	f.save()
 }
 

--- a/items/item_save.go
+++ b/items/item_save.go
@@ -39,6 +39,7 @@ func readItemInfo(rc io.Reader) (*Item, error) {
 			SaveDate:   blob.SaveDate,
 			Creator:    blob.Creator,
 			Size:       blob.ByteCount,
+			MimeType:   blob.MimeType,
 			Bundle:     blob.Bundle,
 			DeleteDate: blob.DeleteDate,
 			Deleter:    blob.Deleter,
@@ -65,6 +66,7 @@ func writeItemInfo(w io.Writer, item *Item) error {
 			ByteCount:  b.Size,
 			MD5:        hex.EncodeToString(b.MD5),
 			SHA256:     hex.EncodeToString(b.SHA256),
+			MimeType:   b.MimeType,
 			SaveDate:   b.SaveDate,
 			Creator:    b.Creator,
 			DeleteDate: b.DeleteDate,
@@ -113,6 +115,7 @@ type blobTape struct {
 	ByteCount  int64
 	MD5        string
 	SHA256     string
+	MimeType   string
 	SaveDate   time.Time
 	Creator    string
 	DeleteDate time.Time

--- a/items/types.go
+++ b/items/types.go
@@ -18,9 +18,10 @@ type Blob struct {
 	Size     int64 // logical size of associated content (i.e. before compression), 0 if deleted
 
 	// following valid if blob is NOT deleted
-	Bundle int    // which bundle file this blob is stored in
-	MD5    []byte // unused if Size == 0
-	SHA256 []byte // unused if Size == 0
+	Bundle   int    // which bundle file this blob is stored in
+	MD5      []byte // unused if Size == 0
+	SHA256   []byte // unused if Size == 0
+	MimeType string // either empty or the mime type of this blob
 
 	// following valid if blob is deleted
 	DeleteDate time.Time // zero iff not deleted

--- a/items/writer.go
+++ b/items/writer.go
@@ -106,6 +106,7 @@ func (wr *Writer) doDeletes() error {
 			blob.DeleteNote = wr.version.Note
 			blob.Bundle = 0
 			blob.Size = 0
+			blob.MimeType = ""
 		}
 	}
 
@@ -223,6 +224,16 @@ func (wr *Writer) SetSlot(s string, id BlobID) {
 // still be around!).
 func (wr *Writer) ClearSlots() {
 	wr.version.Slots = make(map[string]BlobID)
+}
+
+// SetMimeType sets the mime type for the given blob. Nothing is changed if no
+// blob has the given id or if the blob has been deleted.
+func (wr *Writer) SetMimeType(id BlobID, mimetype string) {
+	blob := wr.item.blobByID(id)
+	if blob == nil || blob.Bundle == 0 {
+		return
+	}
+	blob.MimeType = mimetype
 }
 
 // DeleteBlob marks the given blob for removal from the underlying storage.

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -343,6 +343,7 @@ func (c command) Execute(iw *items.Writer, tx *T, cache blobcache.T) {
 			break
 		}
 		tx.BlobMap[cmd[1]] = int(bid)
+		iw.SetMimeType(bid, fstat.MimeType)
 	case "sleep":
 		// sleep for some length of time. intended to be used for testing.
 		// nothing magic about 1 sec. could be less


### PR DESCRIPTION
This adds support to the server to save the mime type of files. There are still two gaps:

* The client does not supply mime types at upload time
* The server download does not return the mime type of a file. This is because the mime type is not cached in the database.

I will submit a PR for the client next, and then I will work on the database updates.