### PR TITLE
Enable overall checksum for uploads

### DIFF
--- a/bclientapi/bendoapi.go
+++ b/bclientapi/bendoapi.go
@@ -145,6 +145,9 @@ func (ia *ItemAttributes) PostUpload(chunk []byte, chunkmd5sum []byte, filemd5su
 	if mimetype != "" {
 		req.Header.Add("Content-Type", mimetype)
 	}
+	if len(filemd5sum) > 0 {
+		req.Header.Add("X-Content-MD5", hex.EncodeToString(filemd5sum))
+	}
 	resp, err := http.DefaultClient.Do(req)
 
 	if err != nil {

--- a/server/upload.go
+++ b/server/upload.go
@@ -144,9 +144,18 @@ func (s *RESTServer) AppendFileHandler(w http.ResponseWriter, r *http.Request, p
 		f.Rollback()
 		return
 	}
+	// populate metadata fields
 	v := r.Header.Get("Content-Type")
 	if v != "" {
 		f.SetMimeType(v)
+	}
+	h := getHexadecimalHeader(r, "X-Content-SHA256")
+	if len(h) > 0 {
+		f.SetSHA256(h)
+	}
+	h = getHexadecimalHeader(r, "X-Content-MD5")
+	if len(h) > 0 {
+		f.SetMD5(h)
 	}
 }
 
@@ -155,9 +164,6 @@ func (s *RESTServer) AppendFileHandler(w http.ResponseWriter, r *http.Request, p
 // or is not valid hexadecimal, returns an empty slice.
 func getHexadecimalHeader(r *http.Request, header string) []byte {
 	v := r.Header.Get(header)
-	if v == "" {
-		return nil
-	}
 	result, _ := hex.DecodeString(v)
 	return result
 }


### PR DESCRIPTION
Most of the code is already in place. Only needed client to sent overall
md5 and have the server look for the header and save it.