### PR TITLE
List transaction errors in bclient

### DIFF
--- a/cmd/bclient/upload.go
+++ b/cmd/bclient/upload.go
@@ -87,7 +87,11 @@ func doUpload(item string, file string) int {
 	}
 
 	if *wait {
-		thisItem.WaitForCommitFinish(transaction)
+		err = thisItem.WaitForCommitFinish(transaction)
+		if err != nil {
+			fmt.Println(err)
+			return 1
+		}
 	}
 
 	return 0


### PR DESCRIPTION
This will make debugging errors easier since they will now appear in the
batch job's log file.