### PR TITLE
Add html template for the /item/:id view

### DIFF
--- a/server/item.go
+++ b/server/item.go
@@ -2,12 +2,13 @@ package server
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"expvar"
 	"fmt"
+	"html/template"
 	"io"
 	"log"
 	"net/http"
+	"reflect"
 	"strconv"
 
 	"github.com/julienschmidt/httprouter"
@@ -197,7 +198,65 @@ func (s *RESTServer) ItemHandler(w http.ResponseWriter, r *http.Request, ps http
 	}
 	vid := item.Versions[len(item.Versions)-1].ID
 	w.Header().Set("ETag", fmt.Sprintf(`"%d"`, vid))
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	enc := json.NewEncoder(w)
-	enc.Encode(item)
+	writeHTMLorJSON(w, r, itemTemplate, item)
+	//w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	//enc := json.NewEncoder(w)
+	//enc.Encode(item)
 }
+
+func minus1(a reflect.Value) int {
+	// when this takes an integer argument, it doesn't work in the template
+	// so make a have interface{}, and reflect to get the right value
+	var x = 1 // so default return is 0
+	switch a.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		x = int(a.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		x = int(a.Uint())
+	}
+	return x - 1
+}
+
+var (
+	itemfns = template.FuncMap{
+		"minus1": minus1,
+	}
+
+	itemTemplate = template.Must(template.New("items").Funcs(itemfns).Parse(`<html>
+<h1>Item {{ .ID }}</h1>
+MaxBundle: {{ .MaxBundle }}<br/>
+{{ $blobs := .Blobs }}
+{{ $id := .ID }}
+{{ with index .Versions (len .Versions | minus1) }}
+	Version: {{ .ID }}<br/>
+	SaveDate: {{ .SaveDate }}<br/>
+	Creator: {{ .Creator }}<br/>
+	Note: {{ .Note }}<br/>
+	<table><thead><tr>
+		<th>Bundle</th>
+		<th>Blob</th>
+		<th>Size</th>
+		<th>Date</th>
+		<th>MimeType</th>
+		<th>MD5</th>
+		<th>SHA256</th>
+		<th>Filename</th>
+	</tr></thead><tbody>
+	{{ range $key, $value := .Slots }}
+		<tr>
+		{{ with index $blobs ($value | minus1) }}
+			<td>{{.Bundle}}</td>
+			<td><a href="/item/{{ $id }}/@blob/{{ $value }}">{{ $value }}</a></td>
+			<td>{{.Size}}</td>
+			<td>{{.SaveDate}}</td>
+			<td>{{.MimeType}}</td>
+			<td>{{ printf "%x" .MD5 }}</td>
+			<td>{{ printf "%x" .SHA256 }}</td>
+		{{ end }}
+		<td><a href="/item/{{ $id }}/{{ $key }}">{{ $key }}</a></td>
+		</tr>
+	{{ end }}
+	</tbody></table>
+{{ end }}
+</html>`))
+)

--- a/server/item.go
+++ b/server/item.go
@@ -199,9 +199,6 @@ func (s *RESTServer) ItemHandler(w http.ResponseWriter, r *http.Request, ps http
 	vid := item.Versions[len(item.Versions)-1].ID
 	w.Header().Set("ETag", fmt.Sprintf(`"%d"`, vid))
 	writeHTMLorJSON(w, r, itemTemplate, item)
-	//w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	//enc := json.NewEncoder(w)
-	//enc.Encode(item)
 }
 
 func minus1(a reflect.Value) int {

--- a/server/routes.go
+++ b/server/routes.go
@@ -339,7 +339,8 @@ func writeHTMLorJSON(w http.ResponseWriter,
 	tmpl *template.Template,
 	val interface{}) {
 
-	if r.Header.Get("Accept-Encoding") == "application/json" {
+	if r.Header.Get("Accept-Encoding") == "application/json" ||
+		r.FormValue("format") == "json" {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		json.NewEncoder(w).Encode(val)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -75,7 +75,7 @@ func TestTransactionCommands(t *testing.T) {
 	// tx is processed async from the commit above.
 	waitTransaction(t, txpath)
 	checkStatus(t, "GET", "/item/"+itemid, 200)
-	text := getbody(t, "GET", "/blob/"+itemid+"/2", 200)
+	text := getbody(t, "GET", "/item/"+itemid+"/@blob/2", 200)
 	if text != "delete me" {
 		t.Errorf("Received %#v, expected %#v", text, "delete me")
 	}
@@ -84,11 +84,11 @@ func TestTransactionCommands(t *testing.T) {
 		[][]string{{"delete", "2"}}, 202)
 	t.Log("got tx path", txpath)
 	waitTransaction(t, txpath)
-	text = getbody(t, "GET", "/blob/"+itemid+"/1", 200)
+	text = getbody(t, "GET", "/item/"+itemid+"/@blob/1", 200)
 	if text != "hello world" {
 		t.Errorf("Received %#v, expected %#v", text, "hello world")
 	}
-	text = getbody(t, "GET", "/blob/"+itemid+"/2", 404)
+	text = getbody(t, "GET", "/item/"+itemid+"/@blob/2", 404)
 	if text != "Blob has been deleted\n" {
 		t.Errorf("Received %#v, expected %#v", text, "Blob has been deleted\n")
 	}


### PR DESCRIPTION
Also, add optional parameter `format=json` to all the routes returning
json, to toggle between html and json. This is to make it easier for
testing in web browsers where setting a content type header is more
difficult.