### PR TITLE
Only return fixity checks from current day

### DIFF
--- a/server/fixity_test.go
+++ b/server/fixity_test.go
@@ -49,7 +49,7 @@ func TestFixityTimeValidation(t *testing.T) {
 	}
 
 	for _, tab := range table {
-		got, err := timeValidate(tab.input)
+		got, err := timeValidate(tab.input, time.Time{})
 		if !tab.valid && err == nil {
 			t.Errorf("For %s expected error", tab.input)
 		}


### PR DESCRIPTION
Change `start` and `end` of Fixity Search queries to default to midnight
of the current day, and of the next day.
This (hopefully, for now) keeps too many results from being returned.

DLTP-1199