### PR TITLE
Add config options for S3 to bendo daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,24 @@ It was designed to fit into a larger digital architecture.
 # Description of this repository
 
 This repository contains the code for the Bendo server, along with related command-line tools, tests, and documentation.
-The server is in `cmd/bendo`.
+The repository is organized as so:
+
+ * `cmd/bendo` is the top-level application
+ * `cmd/bclient` is a command line utility to interact with a bendo server
+ * `server` contains everything relating with the REST API and databases
+ * `blobcache` is the cache logic
+ * `transaction` for the code to create and update items
+ * `items` for reading and writing the stored bundle files
+ * `bagit`, `fragment`, `store` handle details with file format, storage, and organization
+ * `architecture` has some design documents and other guides
+ * `bclientapi` has supporting code for bclient
 
 # Getting Started
 
 To install bendo, first install golang. This is probably easy with a package manager, e.g. `brew install go` or `yum install golang`.
 
-Then install the bendo server by executing `go get github.com/ndlib/bendo/cmd/bendo`.
-In the directory of your hydra application, create a subdirectory to store files, for example `bendo`
+Get and compile the server by executing `go get github.com/ndlib/bendo/cmd/bendo`.
+In the directory of your samvera application create a subdirectory to store files, for example `bendo`
 
     mkdir -p bendo/uploads bendo/store
 
@@ -54,9 +64,9 @@ If you already had files in these directories Bendo will resync itself on them, 
 
 # Copy-On-Write
 
-It is possible for a bendo server to pull content from a second bendo server.
-In this way, the first bendo server will appear to have all the content the second one has, but any writes or changes to the data are kept
-only in the first one.
+It is possible for one bendo server to pull content from a second bendo server.
+In this way, the first bendo server will appear to have all the content the second one has,
+but any writes or changes to the data are kept only in the first one.
 The transfer of data happens in the background, and is not noticiable to any clients.
 The ability is only a proof-of-concept now, and entire bundle files are transferred.
 If the Copy-on-Write ability is useful, the code should be rewritten so that
@@ -69,6 +79,23 @@ If the second bendo server is protected by a token, also give an access token.
     CowToken = "1234567890"
 
 The second bendo server supports the copying by default and does not need to be configured in any way.
+
+# S3
+
+Bendo can use S3 as storage for the cache. To use it specisify the bucket name and an optional prefix
+to use by setting the CacheDir to be `s3:/bucket/prefix`.
+Put the credentials in the envrionment variables `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`.
+
+You can also use it with a local instance of Minio. One way to run Minio is with docker, e.g.
+
+    docker run -p 9000:9000  minio/minio server /shared/data
+
+Then set the `CacheDir` to access this server by supplying a hostname:
+
+    CacheDir = s3://localhost:9000/bucket/prefix
+
+And set the envrionment variables to have the correct access key and secret access key.
+
 
 # Deployment in Production
 

--- a/architecture/cmd_bendo.md
+++ b/architecture/cmd_bendo.md
@@ -40,12 +40,26 @@ Strings are enclosed inside double-quote characters.
 
 Set the directory to use for storing the download cache as well as the temporary storage place for uploaded files.
 If this is not given, everything is kept in memory.
+The path may refer to an S3 bucket using the notation `s3:/bucket/prefix` or
+`s3://hostname:port/bucket/prefix/to/use`. In this case the environment variables
+`AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` are used to supply the credentials
+needed to access that particular S3 bucket.
 
     CacheSize = <MEGABYTES>
 
 Set the maximum cache size, in megabytes (decimal, so passing "1" will set the cache size to 1,000,000 bytes, not 2**20 bytes).
 This size limit applies only to the download cache, not to the temporary storage used for file uploads, so
 the total space used for the cache directory may be larger than the size given.
+
+    CacheTimeout = "<DURATION>"
+
+If set, the time-based eviction strategy is used, and items in the cache are kept
+for the given length of time since the most recent access, and then removed.
+The time is reset if an item is accessed in the interim. Set the duration using
+the letters "s", "m", and "h" for seconds, minutes, and hours. For example, to
+set the timeout to be one day, use `"24h"`. For one month use `"720h"`, etc.
+Leave empty or set to zero to use the size-based cache eviction strategy.
+Defaults to 0.
 
     CowHost = <URL>
 
@@ -54,9 +68,7 @@ This bendo server will refer to the external one whenever an item is requested w
 the local store. Any writes will be saved locally and not on the external bendo.
 When this is enabled, background fixity checking on this bendo server is disabled (since
 otherwise, all the content on the remote bendo server will end up copied to this one).
-An example:
-
-        CowHost = "http://bendo.example.org:14000/"
+An example: `CowHost = "http://bendo.example.org:14000/"`
 
     CowToken = "<Token>"
 

--- a/blobcache/timebased.go
+++ b/blobcache/timebased.go
@@ -340,4 +340,5 @@ func (te *TimeBased) scanstore() {
 func (te *TimeBased) Scan() {
 	te.readIndexFile()
 	te.scanstore()
+	te.writeIndexFile() // make sure things we just scanned end up in the index
 }

--- a/config.example
+++ b/config.example
@@ -1,6 +1,9 @@
 StoreDir = "./bendo_storage"
 CacheDir = "./bendo_cache"
+# if CacheTimeout is given, then CacheSize is ignored
+# Only one cache-strategy is possible at a time
 CacheSize = 1000   # in MB
+CacheTimeout = "2160h"  # 90 days
 Mysql = "/test"
 CowHost = ""
 CowToken = ""

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/ndlib/bendo/store"
+)
+
+const (
+	typeMemory = iota
+	typeFileSystem
+	typeS3
+)
+
+func TestGetCacheStore(t *testing.T) {
+	var table = []struct {
+		cachedir string
+		typ      int
+		bucket   string
+		prefix   string
+	}{
+		{"", typeMemory, "", ""},
+		{"rel/path", typeFileSystem, "", ""},
+		{"/abs/path/", typeFileSystem, "", ""},
+		{"file:/rel/path", typeFileSystem, "", ""},
+		{"file:rel/path", typeFileSystem, "", ""},
+		{"s3:/bucket", typeS3, "bucket", ""},
+		{"s3://localhost:9000/bucket/prefix/", typeS3, "bucket", "prefix/"},
+	}
+
+	for _, row := range table {
+		t.Log(row.cachedir)
+		s := &RESTServer{CacheDir: row.cachedir}
+		result := s.getcachestore("")
+		switch x := result.(type) {
+		case *store.Memory:
+			if row.typ != typeMemory {
+				t.Errorf("unexpected received %#v", result)
+			}
+		case *store.FileSystem:
+			if row.typ != typeFileSystem {
+				t.Errorf("unexpected received %#v", result)
+			}
+		case *store.S3:
+			if row.typ != typeS3 {
+				t.Errorf("unexpected received %#v", result)
+			}
+			if x.Bucket != row.bucket {
+				t.Error("expected bucket", row.bucket, "received", x.Bucket)
+			}
+			if x.Prefix != row.prefix {
+				t.Error("expected prefix", row.prefix, "received", x.Prefix)
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Provide it using an s3:// URL as the cache directory.
* Add config option to use the time-based cache evection strategy.
* Always write tim-based cache index file after a scan. This ensures
items get timestamped in case the server is restarted before the next
index save.