### PR TITLE
update output encryption so artifacts are able to be pulled by default

### DIFF
--- a/codebuild.yml
+++ b/codebuild.yml
@@ -110,6 +110,7 @@ Resources:
         Path: bendo
         Name: rpms
         Location: !If [NoBucket, !Ref Bucket, !Ref TargetBucket]
+        EncryptionDisabled: true
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
Adding a line so that CodeBuild doesn't encrypt artifacts by default. This will allow the artifacts to be usable without ESU intervention.