### PR TITLE
Make S3 writes synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,16 @@ Put the credentials in the environment variables `AWS_ACCESS_KEY` and `AWS_SECRE
 
 You can use a local instance of Minio as well. For example, using docker:
 
-    docker run -p 9000:9000  minio/minio server /shared/data
+    docker run -p 9000:9000 -e "MINIO_ACCESS_KEY=bob" -e "MINIO_SECRET_KEY=1234567890" minio/minio server /data
 
 Then set the `CacheDir` to access this server by supplying a host name:
 
     CacheDir = s3://localhost:9000/bucket/prefix
 
 And set the environment variables to have the correct access key and secret access key.
+To run the S3 tests in the `store/` directory run
+
+    env "AWS_ACCESS_KEY_ID=bob" "AWS_SECRET_ACCESS_KEY=1234567890" go test -tags=s3 -run S3
 
 
 # Sentry

--- a/blobcache/timebased.go
+++ b/blobcache/timebased.go
@@ -300,6 +300,8 @@ func (te *TimeBased) writeIndexFile() {
 func (te *TimeBased) readIndexFile() {
 	rac, _, err := te.s.Open(indexFilename)
 	if err != nil {
+		// If the index file does not already exist, it will generate an error.
+		// Is is not a problem, but we log the error anyway.
 		log.Println("Error opening", indexFilename, ":", err)
 		raven.CaptureError(err, nil)
 		return


### PR DESCRIPTION
Previously the writes were async. Synchronous makes the code much simpler.

Many other small AWS errors fixed:
* Ensure all errors from S3 are captured.
* AWS wants 1 based part numbers
* Return an error if we don't get an ETag from AWS.

Add some comments about time-based blobcache. It is expected to have
errors at first since the index file will be missing from the store. but
still log the error since we don't know what the error is exactly.