### PR TITLE
Improve transaction error handling

### DIFF
--- a/fragment/fragment.go
+++ b/fragment/fragment.go
@@ -73,7 +73,7 @@ type FileEntry interface {
 
 	// Verify the checksums of this file. Returns true if they match,
 	// and false otherwise.
-	Verify() bool
+	Verify() (bool, error)
 }
 
 // Stat contains the metadata for a file entry.
@@ -361,11 +361,11 @@ func (f *file) save() error {
 // Returns true if the MD5 and SHA256 checksums set on this file match the
 // checksums of the file's contents. If a checksum is not provided, then it
 // is not checked. If neither checksum is provided, then returns true.
-func (f *file) Verify() bool {
+// If an error occured while trying to verify the checksums, the error is returned and the bool value should be ignored.
+func (f *file) Verify() (bool, error) {
 	r := f.Open()
 	defer r.Close()
-	ok, _ := util.VerifyStreamHash(r, f.MD5, f.SHA256)
-	return ok
+	return util.VerifyStreamHash(r, f.MD5, f.SHA256)
 }
 
 func (f *file) SetCreator(name string) {

--- a/items/bundler_test.go
+++ b/items/bundler_test.go
@@ -16,10 +16,11 @@ func TestBundleWriter(t *testing.T) {
 	}
 	blob := &Blob{ID: 1}
 	item.Blobs = append(item.Blobs, blob)
-	err := bw.WriteBlob(blob, strings.NewReader("Hello There"))
+	result, err := bw.WriteBlob(blob, strings.NewReader("Hello There"))
 	if err != nil {
 		t.Fatalf("WriteBlob() == %s, expected nil", err.Error())
 	}
+	blob.Bundle = result.Bundle
 	err = bw.Close()
 	if err != nil {
 		t.Fatalf("Close() == %s, expected nil", err.Error())

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -256,7 +256,10 @@ func (tx *T) VerifyFiles(files *fragment.Store) {
 			tx.AppendError("Missing file " + fid)
 			continue
 		}
-		if !f.Verify() {
+		ok, err := f.Verify()
+		if err != nil {
+			tx.AppendError("Checking " + fid + ": " + err.Error())
+		} else if !ok {
 			tx.AppendError("Checksum mismatch for " + fid)
 		}
 	}


### PR DESCRIPTION
* change the bundle writing process to make sure the blob list is in a
consistent state in the case of copy errors. Always make an entry for a
blob if it was created in a bundle file. Also return read errors when
copying a file into a bundle.

* change transaction processing to stop when the verify step found
errors. (previously it just logged them). Also make verify more
sensitive to whether there was a checksum mismatch or a general error.
This changes the fragment Verify() to return a (bool, error) pair
instead of only a bool.

Addresses DLTP-1676