### PR TITLE
Adding logger to address error coercion

### DIFF
--- a/items/item.go
+++ b/items/item.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -137,7 +138,7 @@ func (s *Store) itemload(id string) (*Item, error) {
 func (s *Store) findMaxBundle(id string) int {
 	bundles, err := s.S.ListPrefix(id)
 	if err != nil {
-		// TODO(dbrower): log the error or just lose it?
+		log.Println(id, ":", err)
 		return 0
 	}
 	var max int

--- a/store/file_store_test.go
+++ b/store/file_store_test.go
@@ -88,6 +88,11 @@ func TestListPrefix(t *testing.T) {
 		{"abcde", []string{
 			"abcdef-0001",
 		}},
+		{"z", []string{}},
+		{"zz", []string{}},
+		{"zzz", []string{}},
+		{"zzzz", []string{}},
+		{"zzzzz", []string{}},
 	}
 	dir := makeTmpTree(files)
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
In following the Bendo code, I'm losing the context for why the
MaxBundle cannot be found. The below is the code in which an apparent
error is coerced into 0.

```go
func (s *Store) itemload(id string) (*Item, error) {
        n := s.findMaxBundle(id)
        if n == 0 {
                return nil, ErrNoItem
        }
```

This commit adds logging to the particular error.