### PR TITLE
Refactor blob caching path

### DIFF
--- a/blobcache/writer.go
+++ b/blobcache/writer.go
@@ -41,8 +41,12 @@ func (w *writer) Write(p []byte) (int, error) {
 		}
 		return 0, err
 	}
-	// w.size will be >= the actual item size since we don't use the actual
-	// amount written. Perhaps that does need to be tracked.
-	w.size += int64(n)
-	return w.w.Write(p)
+	x, err := w.w.Write(p)
+	w.size += int64(x)
+	if err != nil {
+		// Since there was a write error, remove this entry from the
+		// cache when the time comes.
+		w.deleteOnClose = true
+	}
+	return x, err
 }


### PR DESCRIPTION
Since the blob caching path is very important, restructure it so it
singleflights blob caching when many people want the same blob. Also be
clearer with what is happening inline in the requests and what is
happening in the background. Finally, add more logging to the procedure
to help understand the issues we seem to be having with S3.