### PR TITLE
Refactor bclient 2

### DIFF
--- a/bclientapi/bclientapi.go
+++ b/bclientapi/bclientapi.go
@@ -3,6 +3,7 @@ package bclientapi
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"time"
 
@@ -17,6 +18,9 @@ type Connection struct {
 
 	ChunkSize int
 	Token     string
+
+	// use this to make http requests. It is configured with a timeout.
+	client *http.Client
 }
 
 // upload the give file to the bendo server

--- a/bclientapi/bclientapi.go
+++ b/bclientapi/bclientapi.go
@@ -21,23 +21,6 @@ type Connection struct {
 	Token     string
 }
 
-// serve file requests from the server for  a get
-// If the file Get fails, close the channel and exit
-
-func (c *Connection) GetFiles(item string, fileQueue chan string, pathPrefix string) error {
-
-	for filename := range fileQueue {
-		err := c.downLoad(item, filename, pathPrefix)
-
-		if err != nil {
-			fmt.Printf("Error: GetFile return %s\n", err.Error())
-			return err
-		}
-	}
-
-	return nil
-}
-
 // upload the give file to the bendo server
 
 func (c *Connection) UploadFile(item string, filename string, uploadMd5 []byte, mimetype string) error {

--- a/bclientapi/bclientapi.go
+++ b/bclientapi/bclientapi.go
@@ -16,7 +16,6 @@ type Connection struct {
 	HostURL string
 
 	Fileroot  string
-	Item      string
 	ChunkSize int
 	Wait      bool
 	Token     string
@@ -25,10 +24,10 @@ type Connection struct {
 // serve file requests from the server for  a get
 // If the file Get fails, close the channel and exit
 
-func (c *Connection) GetFiles(fileQueue chan string, pathPrefix string) error {
+func (c *Connection) GetFiles(item string, fileQueue chan string, pathPrefix string) error {
 
 	for filename := range fileQueue {
-		err := c.downLoad(filename, pathPrefix)
+		err := c.downLoad(item, filename, pathPrefix)
 
 		if err != nil {
 			fmt.Printf("Error: GetFile return %s\n", err.Error())
@@ -41,14 +40,14 @@ func (c *Connection) GetFiles(fileQueue chan string, pathPrefix string) error {
 
 // upload the give file to the bendo server
 
-func (c *Connection) UploadFile(filename string, uploadMd5 []byte, mimetype string) error {
-	_, err := c.chunkAndUpload(filename, uploadMd5, mimetype)
+func (c *Connection) UploadFile(item string, filename string, uploadMd5 []byte, mimetype string) error {
+	_, err := c.chunkAndUpload(item, filename, uploadMd5, mimetype)
 
 	// If an error occurred, report it, and return
 
 	if err != nil {
 		// add api call to delete fileid uploads
-		fmt.Printf("Error: unable to upload file %s for item %s, %s\n", filename, c.Item, err)
+		fmt.Printf("Error: unable to upload file %s for item %s, %s\n", filename, item, err)
 		return err
 	}
 

--- a/bclientapi/bclientapi.go
+++ b/bclientapi/bclientapi.go
@@ -15,9 +15,7 @@ type Connection struct {
 	// The bendo server this connection is to
 	HostURL string
 
-	Fileroot  string
 	ChunkSize int
-	Wait      bool
 	Token     string
 }
 

--- a/bclientapi/bendoapi.go
+++ b/bclientapi/bendoapi.go
@@ -24,8 +24,8 @@ var (
 	ErrServerError      = errors.New("Server Error")
 )
 
-func (c *Connection) GetItemInfo() (*jason.Object, error) {
-	return c.doJasonGet("/item/" + c.Item)
+func (c *Connection) GetItemInfo(item string) (*jason.Object, error) {
+	return c.doJasonGet("/item/" + item)
 }
 
 // get upload metadata (if it exists) . Assumes that the upload fileid is item#-filemd5sum
@@ -35,8 +35,8 @@ func (c *Connection) getUploadMeta(fileId string) (*jason.Object, error) {
 	return c.doJasonGet("/upload/" + fileId + "/metadata")
 }
 
-func (c *Connection) downLoad(fileName string, pathPrefix string) error {
-	var httpPath = c.HostURL + "/item/" + c.Item + "/" + fileName
+func (c *Connection) downLoad(item string, fileName string, pathPrefix string) error {
+	var httpPath = c.HostURL + "/item/" + item + "/" + fileName
 
 	req, _ := http.NewRequest("GET", httpPath, nil)
 	if c.Token != "" {
@@ -131,9 +131,9 @@ func (c *Connection) PostUpload(chunk []byte, chunkmd5sum []byte, filemd5sum []b
 
 // Not well named - sets a POST /item/:id/transaction
 
-func (c *Connection) CreateTransaction(cmdlist []byte) (string, error) {
+func (c *Connection) CreateTransaction(item string, cmdlist []byte) (string, error) {
 
-	var path = c.HostURL + "/item/" + c.Item + "/transaction"
+	var path = c.HostURL + "/item/" + item + "/transaction"
 
 	req, _ := http.NewRequest("POST", path, bytes.NewReader(cmdlist))
 	if c.Token != "" {

--- a/bclientapi/bendoapi.go
+++ b/bclientapi/bendoapi.go
@@ -24,23 +24,23 @@ var (
 	ErrServerError      = errors.New("Server Error")
 )
 
-func (ia *ItemAttributes) GetItemInfo() (*jason.Object, error) {
-	return ia.doJasonGet("/item/" + ia.item)
+func (c *Connection) GetItemInfo() (*jason.Object, error) {
+	return c.doJasonGet("/item/" + c.Item)
 }
 
 // get upload metadata (if it exists) . Assumes that the upload fileid is item#-filemd5sum
 // returns json of metadata if successful, error otherwise
 
-func (ia *ItemAttributes) getUploadMeta(fileId string) (*jason.Object, error) {
-	return ia.doJasonGet("/upload/" + fileId + "/metadata")
+func (c *Connection) getUploadMeta(fileId string) (*jason.Object, error) {
+	return c.doJasonGet("/upload/" + fileId + "/metadata")
 }
 
-func (ia *ItemAttributes) downLoad(fileName string, pathPrefix string) error {
-	var httpPath = ia.bendoServer + "/item/" + ia.item + "/" + fileName
+func (c *Connection) downLoad(fileName string, pathPrefix string) error {
+	var httpPath = c.HostURL + "/item/" + c.Item + "/" + fileName
 
 	req, _ := http.NewRequest("GET", httpPath, nil)
-	if ia.token != "" {
-		req.Header.Add("X-Api-Key", ia.token)
+	if c.Token != "" {
+		req.Header.Add("X-Api-Key", c.Token)
 	}
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -85,14 +85,14 @@ func (ia *ItemAttributes) downLoad(fileName string, pathPrefix string) error {
 	return err
 }
 
-func (ia *ItemAttributes) PostUpload(chunk []byte, chunkmd5sum []byte, filemd5sum []byte, mimetype string, fileId string) error {
+func (c *Connection) PostUpload(chunk []byte, chunkmd5sum []byte, filemd5sum []byte, mimetype string, fileId string) error {
 
-	var path = ia.bendoServer + "/upload/" + fileId
+	var path = c.HostURL + "/upload/" + fileId
 
 	req, _ := http.NewRequest("POST", path, bytes.NewReader(chunk))
 	req.Header.Set("X-Upload-Md5", hex.EncodeToString(chunkmd5sum))
-	if ia.token != "" {
-		req.Header.Add("X-Api-Key", ia.token)
+	if c.Token != "" {
+		req.Header.Add("X-Api-Key", c.Token)
 	}
 	if mimetype != "" {
 		req.Header.Add("Content-Type", mimetype)
@@ -131,13 +131,13 @@ func (ia *ItemAttributes) PostUpload(chunk []byte, chunkmd5sum []byte, filemd5su
 
 // Not well named - sets a POST /item/:id/transaction
 
-func (ia *ItemAttributes) CreateTransaction(cmdlist []byte) (string, error) {
+func (c *Connection) CreateTransaction(cmdlist []byte) (string, error) {
 
-	var path = ia.bendoServer + "/item/" + ia.item + "/transaction"
+	var path = c.HostURL + "/item/" + c.Item + "/transaction"
 
 	req, _ := http.NewRequest("POST", path, bytes.NewReader(cmdlist))
-	if ia.token != "" {
-		req.Header.Add("X-Api-Key", ia.token)
+	if c.Token != "" {
+		req.Header.Add("X-Api-Key", c.Token)
 	}
 	resp, err := http.DefaultClient.Do(req)
 
@@ -156,12 +156,12 @@ func (ia *ItemAttributes) CreateTransaction(cmdlist []byte) (string, error) {
 	return transaction, nil
 }
 
-func (ia *ItemAttributes) getTransactionStatus(transaction string) (*jason.Object, error) {
-	return ia.doJasonGet("/transaction/" + transaction)
+func (c *Connection) getTransactionStatus(transaction string) (*jason.Object, error) {
+	return c.doJasonGet("/transaction/" + transaction)
 }
 
-func (ia *ItemAttributes) doJasonGet(path string) (*jason.Object, error) {
-	path = ia.bendoServer + path
+func (c *Connection) doJasonGet(path string) (*jason.Object, error) {
+	path = c.HostURL + path
 
 	req, err := http.NewRequest("GET", path, nil)
 
@@ -170,8 +170,8 @@ func (ia *ItemAttributes) doJasonGet(path string) (*jason.Object, error) {
 	}
 
 	req.Header.Set("Accept-Encoding", "application/json")
-	if ia.token != "" {
-		req.Header.Add("X-Api-Key", ia.token)
+	if c.Token != "" {
+		req.Header.Add("X-Api-Key", c.Token)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/bclientapi/bendoapi.go
+++ b/bclientapi/bendoapi.go
@@ -25,7 +25,7 @@ var (
 	ErrServerError      = errors.New("Server Error")
 )
 
-func (c *Connection) GetItemInfo(item string) (*jason.Object, error) {
+func (c *Connection) ItemInfo(item string) (*jason.Object, error) {
 	return c.doJasonGet("/item/" + item)
 }
 

--- a/bclientapi/chunkfile.go
+++ b/bclientapi/chunkfile.go
@@ -9,13 +9,13 @@ import (
 	"path"
 )
 
-func (ia *ItemAttributes) chunkAndUpload(srcFile string, srcFileMd5 []byte, mimetype string) (string, error) {
-	var fileID = ia.item + "-" + hex.EncodeToString(srcFileMd5)
+func (c *Connection) chunkAndUpload(srcFile string, srcFileMd5 []byte, mimetype string) (string, error) {
+	var fileID = c.Item + "-" + hex.EncodeToString(srcFileMd5)
 
 	// check to see if metadata exists for this fileID
 	// if so, get size of data already uploaded
 	var offset int64
-	json, err := ia.getUploadMeta(fileID)
+	json, err := c.getUploadMeta(fileID)
 	if err == nil {
 		offset, _ = json.GetInt64("Size")
 	}
@@ -32,7 +32,7 @@ func (ia *ItemAttributes) chunkAndUpload(srcFile string, srcFileMd5 []byte, mime
 		return "", err
 	}
 
-	chunk := make([]byte, ia.chunkSize)
+	chunk := make([]byte, c.ChunkSize)
 
 	// upload the file in chunks
 
@@ -62,7 +62,7 @@ func (ia *ItemAttributes) chunkAndUpload(srcFile string, srcFileMd5 []byte, mime
 			err = errors.New("Too many attempts to upload chunk")
 			break
 		}
-		err = ia.PostUpload(chunk[:n], chMd5[:], srcFileMd5, mimetype, fileID)
+		err = c.PostUpload(chunk[:n], chMd5[:], srcFileMd5, mimetype, fileID)
 		if err == ErrChecksumMismatch || err == ErrServerError {
 			retryCount++
 			goto retry

--- a/bclientapi/chunkfile.go
+++ b/bclientapi/chunkfile.go
@@ -9,8 +9,8 @@ import (
 	"path"
 )
 
-func (c *Connection) chunkAndUpload(srcFile string, srcFileMd5 []byte, mimetype string) (string, error) {
-	var fileID = c.Item + "-" + hex.EncodeToString(srcFileMd5)
+func (c *Connection) chunkAndUpload(item string, srcFile string, srcFileMd5 []byte, mimetype string) (string, error) {
+	var fileID = item + "-" + hex.EncodeToString(srcFileMd5)
 
 	// check to see if metadata exists for this fileID
 	// if so, get size of data already uploaded

--- a/bclientapi/chunkfile.go
+++ b/bclientapi/chunkfile.go
@@ -1,76 +1,142 @@
 package bclientapi
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"io"
-	"os"
-	"path"
+	"log"
+	"net/http"
+	"sync"
 )
 
-func (c *Connection) chunkAndUpload(item string, srcFile string, srcFileMd5 []byte, mimetype string) (string, error) {
-	var fileID = item + "-" + hex.EncodeToString(srcFileMd5)
-
-	// check to see if metadata exists for this fileID
-	// if so, get size of data already uploaded
-	var offset int64
-	json, err := c.getUploadMeta(fileID)
-	if err == nil {
-		offset, _ = json.GetInt64("Size")
+// upload copies the content from the ReadSeeker to the remote server, giving it
+// the temporary name of `uploadname`. It uses the provided FileInfo to do this.
+// If MD5 is not provided in the FileInfo, it will be calculated before doing
+// the transfer. If the file has already been uploaded or only uploaded partially,
+// we will resume the transfer where it was left off.
+func (c *Connection) upload(uploadname string, r io.ReadSeeker, info FileInfo) error {
+	if len(info.MD5) == 0 {
+		// Since no md5 sum was suppled, calculate it. Need to do this before
+		// uploading the file
+		hw := md5.New()
+		_, err := io.Copy(hw, r)
+		if err != nil {
+			return err
+		}
+		info.MD5 = hw.Sum(nil)
+	}
+	if info.Size == 0 {
+		// no size was provided, so figure it out (since we have Seeker)
+		size, err := r.Seek(0, io.SeekEnd)
+		if err != nil {
+			return err
+		}
+		info.Size = size
 	}
 
-	sourceFile, err := os.Open(srcFile)
-	if err != nil {
-		return fileID, err
+	// if there is an error, we assume the file just hasn't been uploaded yet
+	remoteinfo, _ := c.getUploadInfo(uploadname)
+	if len(remoteinfo.MD5) > 0 && !bytes.Equal(remoteinfo.MD5, info.MD5) {
+		// the prior upload was for something different?
+		// should delete and upload from beginning.
+		// TODO(dbrower): delete and upload from beginning
+		return ErrUnexpectedResp
 	}
-	defer sourceFile.Close()
-
+	if remoteinfo.Size == info.Size {
+		// it is already uploaded
+		return nil
+	}
 	// start upload where we left off, in case we were interrupted
-	_, err = sourceFile.Seek(offset, io.SeekStart)
+	_, err := r.Seek(remoteinfo.Size, io.SeekStart)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	chunk := make([]byte, c.ChunkSize)
+	// special case zero length files.
+	if info.Size == 0 {
+		emptyMD5 := []byte{
+			0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04, 0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e,
+		}
+		err = c.upload0(uploadname, nil, emptyMD5, info)
+		return err
+	}
 
 	// upload the file in chunks
-
-	// we need to special case zero-length files to force an empty body to be
-	// sent. How do we know if a file is zero length? We don't. We make sure to
-	// send a (possibly empty) chunk the first time through the loop, with an
-	// optimization that files we are resuming are not empty.
-	needSendEmptyChunk := offset == 0
-	for {
-		var n int
-		n, err = sourceFile.Read(chunk)
-
-		if err != nil && err != io.EOF {
-			break
-		}
-		err = nil // if there was an error, it was io.EOF
-		// need flag so loop will exit the second time through
-		if n == 0 && !needSendEmptyChunk {
-			break
-		}
-		needSendEmptyChunk = false
-		chMd5 := md5.Sum(chunk[:n])
-		// try to upload a chunk at most 5 times
-		var retryCount = 0
-	retry:
-		if retryCount >= 5 {
-			err = errors.New("Too many attempts to upload chunk")
-			break
-		}
-		err = c.PostUpload(chunk[:n], chMd5[:], srcFileMd5, mimetype, fileID)
-		if err == ErrChecksumMismatch || err == ErrServerError {
-			retryCount++
-			goto retry
-		}
-		if err != nil {
-			break
+	var chunk []byte
+	if c.chunkpool == nil {
+		c.chunkpool = &sync.Pool{}
+	}
+	if b := c.chunkpool.Get(); b != nil {
+		chunk = b.([]byte)
+		if len(chunk) != c.ChunkSize {
+			// the buffer we got is the wrong size. forget about it
+			chunk = nil
 		}
 	}
+	if chunk == nil {
+		if c.ChunkSize == 0 {
+			c.ChunkSize = 10 * (1 << 20) // default is 10 MB
+		}
+		chunk = make([]byte, c.ChunkSize)
+	}
+	defer c.chunkpool.Put(chunk)
+bigloop:
+	for {
+		n, err := r.Read(chunk)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if n == 0 {
+			// nothing more to read?
+			return nil
+		}
 
-	return path.Base(fileID), err
+		chunkMD5 := md5.Sum(chunk[:n])
+
+		// try to upload a chunk at most 5 times
+		for i := 0; i < 5; i++ {
+			err = c.upload0(uploadname, chunk[:n], chunkMD5[:], info)
+			if err == nil {
+				continue bigloop
+			}
+			// otherwise there was some kind of error. Try again.
+		}
+		// too many retries
+		return err
+	}
+}
+
+// upload0 sends a single fragment of a file to the server.
+func (c *Connection) upload0(uploadname string, chunk []byte, chunkmd5sum []byte, info FileInfo) error {
+	path := c.HostURL + "/upload/" + uploadname
+
+	req, _ := http.NewRequest("POST", path, bytes.NewReader(chunk))
+	req.Header.Set("X-Upload-Md5", hex.EncodeToString(chunkmd5sum))
+	if info.Mimetype != "" {
+		req.Header.Add("Content-Type", info.Mimetype)
+	}
+	if len(info.MD5) > 0 {
+		req.Header.Add("X-Content-MD5", hex.EncodeToString(info.MD5))
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 200:
+		return nil
+	case 412:
+		return ErrChecksumMismatch
+	default:
+		message := make([]byte, 512)
+		resp.Body.Read(message)
+		log.Printf("Received HTTP status %d for %s\n", resp.StatusCode, path)
+		log.Println(string(message))
+		return errors.New(string(message))
+	}
 }

--- a/bclientapi/chunkfile_test.go
+++ b/bclientapi/chunkfile_test.go
@@ -1,0 +1,68 @@
+package bclientapi
+
+import (
+	"bytes"
+	"log"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ndlib/bendo/blobcache"
+	"github.com/ndlib/bendo/fragment"
+	"github.com/ndlib/bendo/items"
+	"github.com/ndlib/bendo/server"
+	"github.com/ndlib/bendo/store"
+	"github.com/ndlib/bendo/transaction"
+)
+
+func TestChunkAndUpload(t *testing.T) {
+	data := "0123456789abcdefghijklmnopqrstuvwxyz"
+	r := bytes.NewReader([]byte(data))
+	md5 := []byte{0xe9, 0xb1, 0x71, 0x3d, 0xb6, 0x20, 0xf1, 0xe3, 0xa1, 0x4b, 0x68, 0x12, 0xde, 0x52, 0x3f, 0x4b}
+
+	for i := 0; i < 8; i++ {
+		log.Println("i=", i)
+		eserver, remote := NewLocalBendoServer()
+		// set this to give an error on the ith API call.
+		eserver.Reset([]Play{Play{When: i, Status: 412}})
+
+		conn := &Connection{
+			HostURL:   remote.URL,
+			ChunkSize: 10, // bytes
+		}
+
+		err := conn.upload("qwerty-12345", r, FileInfo{MD5: md5, Mimetype: "application/other"})
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestUpload(t *testing.T) {
+	_, remote := NewLocalBendoServer()
+
+	c := &Connection{
+		HostURL:   remote.URL,
+		ChunkSize: 10, // bytes
+	}
+	data := "0123456789abcdefghijklmnopqrstuvwxyz"
+	r := bytes.NewReader([]byte(data))
+
+	err := c.Upload("abcd", r, FileInfo{})
+	t.Log(err)
+}
+
+func NewLocalBendoServer() (*ErrorServer, *httptest.Server) {
+	db, _ := server.NewQlCache("memory--server")
+	bendo := &server.RESTServer{
+		Validator:      server.NobodyValidator{},
+		Items:          items.NewWithCache(store.NewMemory(), items.NewMemoryCache()),
+		TxStore:        transaction.New(store.NewMemory()),
+		FileStore:      fragment.New(store.NewMemory()),
+		Cache:          blobcache.NewLRU(store.NewMemory(), 400),
+		FixityDatabase: db,
+		//useTape:        true,
+	}
+
+	e := &ErrorServer{h: bendo.Handler()}
+	return e, httptest.NewServer(e)
+}

--- a/bclientapi/server_test.go
+++ b/bclientapi/server_test.go
@@ -1,0 +1,64 @@
+package bclientapi
+
+import (
+	"log"
+	"net/http"
+	"sort"
+	"sync"
+)
+
+// An ErrorServer wraps another http.Handler and injects errors as
+// described by a given playbook. A playbook is given by calling
+// Reset(). Each call to ServeHTTP on the server increments a count
+// starting at 0. A play gives a count to activate, and when the
+// server reaches that count it will return the given Status and
+// Body. Otherwise, requests are passed on to the wrapped handler.
+// This is safe for concurrent use.
+type ErrorServer struct {
+	h http.Handler
+
+	m        sync.Mutex
+	count    int
+	playbook []Play
+}
+
+type Play struct {
+	When   int
+	Status int
+	Body   string
+}
+
+func (s *ErrorServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	s.m.Lock()
+	count := s.count
+	s.count++
+	log.Printf("(%d) %s %s\n", count, req.Method, req.URL)
+	for len(s.playbook) > 0 && s.playbook[0].When <= count {
+		p := s.playbook[0]
+		s.playbook = s.playbook[1:]
+		if p.When < count {
+			// more than one play had same count. Ignore the rest.
+			continue
+		}
+		s.m.Unlock()
+		w.WriteHeader(p.Status)
+		w.Write([]byte(p.Body))
+		return
+	}
+	s.m.Unlock()
+	s.h.ServeHTTP(w, req)
+}
+
+func (s *ErrorServer) Reset(playbook []Play) {
+	s.m.Lock()
+	s.count = 0
+	s.playbook = playbook[:]
+	sort.Sort(ByWhen(s.playbook))
+	s.m.Unlock()
+}
+
+type ByWhen []Play
+
+func (p ByWhen) Len() int           { return len(p) }
+func (p ByWhen) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p ByWhen) Less(i, j int) bool { return p[i].When < p[j].When }

--- a/cmd/bclient/main.go
+++ b/cmd/bclient/main.go
@@ -167,9 +167,7 @@ func doGet(item string, files []string) int {
 
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
-		Wait:      *wait,
 		Token:     *token,
 	}
 	fileLists := NewLists(*fileroot)
@@ -276,9 +274,7 @@ func doGetStub(item string) int {
 
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
-		Wait:      *wait,
 		Token:     *token,
 	}
 
@@ -307,9 +303,7 @@ func doHistory(item string) int {
 
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
-		Wait:      *wait,
 		Token:     *token,
 	}
 
@@ -338,9 +332,7 @@ func doLs(item string) int {
 
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
-		Wait:      *wait,
 		Token:     *token,
 	}
 

--- a/cmd/bclient/main.go
+++ b/cmd/bclient/main.go
@@ -165,9 +165,8 @@ func doGet(item string, files []string) int {
 
 	// set up communication to the bendo server, and init local and remote filelists
 
-	thisItem := &bclientapi.Connection{
+	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Item:      item,
 		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
 		Wait:      *wait,
@@ -176,7 +175,7 @@ func doGet(item string, files []string) int {
 	fileLists := NewLists(*fileroot)
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = thisItem.GetItemInfo()
+	json, jsonFetchErr = conn.GetItemInfo(item)
 
 	// If not found or error, we're done
 
@@ -209,7 +208,7 @@ func doGet(item string, files []string) int {
 	for cnt := int(0); cnt < *numuploaders; cnt++ {
 		go func() {
 			defer getFileDone.Done()
-			err := thisItem.GetFiles(filesToGet, pathPrefix)
+			err := conn.GetFiles(item, filesToGet, pathPrefix)
 			if err != nil {
 				// try to send error back without blocking
 				select {
@@ -254,9 +253,8 @@ func doGetStub(item string) int {
 
 	// fetch info about this item from the bendo server
 
-	thisItem := &bclientapi.Connection{
+	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Item:      item,
 		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
 		Wait:      *wait,
@@ -264,7 +262,7 @@ func doGetStub(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = thisItem.GetItemInfo()
+	json, jsonFetchErr = conn.GetItemInfo(item)
 
 	// If not found or error, we're done; otherwise, create Item Stub
 
@@ -286,9 +284,8 @@ func doHistory(item string) int {
 	var json *jason.Object
 	var jsonFetchErr error
 
-	thisItem := &bclientapi.Connection{
+	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Item:      item,
 		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
 		Wait:      *wait,
@@ -296,7 +293,7 @@ func doHistory(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = thisItem.GetItemInfo()
+	json, jsonFetchErr = conn.GetItemInfo(item)
 
 	switch {
 	case jsonFetchErr == bclientapi.ErrNotFound:
@@ -318,9 +315,8 @@ func doLs(item string) int {
 	var json *jason.Object
 	var jsonFetchErr error
 
-	thisItem := &bclientapi.Connection{
+	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Item:      item,
 		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
 		Wait:      *wait,
@@ -328,7 +324,7 @@ func doLs(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = thisItem.GetItemInfo()
+	json, jsonFetchErr = conn.GetItemInfo(item)
 
 	switch {
 	case jsonFetchErr == bclientapi.ErrNotFound:

--- a/cmd/bclient/main.go
+++ b/cmd/bclient/main.go
@@ -170,7 +170,7 @@ func doGet(item string, files []string) int {
 	fileLists := NewLists(*fileroot)
 
 	// Fetch Item Info from bclientapi
-	json, err := conn.GetItemInfo(item)
+	json, err := conn.ItemInfo(item)
 
 	// If not found or error, we're done
 
@@ -273,7 +273,7 @@ func doGetStub(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, err := conn.GetItemInfo(item)
+	json, err := conn.ItemInfo(item)
 
 	// If not found or error, we're done; otherwise, create Item Stub
 
@@ -298,7 +298,7 @@ func doHistory(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, err := conn.GetItemInfo(item)
+	json, err := conn.ItemInfo(item)
 
 	switch {
 	case err == bclientapi.ErrNotFound:
@@ -322,7 +322,7 @@ func doLs(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, err := conn.GetItemInfo(item)
+	json, err := conn.ItemInfo(item)
 
 	switch {
 	case err == bclientapi.ErrNotFound:

--- a/cmd/bclient/main.go
+++ b/cmd/bclient/main.go
@@ -12,7 +12,6 @@ import (
 	"runtime/pprof"
 	"sync"
 
-	"github.com/antonholmquist/jason"
 	"github.com/ndlib/bendo/bclientapi"
 )
 
@@ -155,8 +154,6 @@ func main() {
 //  Given one or more files in the item, it returns only them
 
 func doGet(item string, files []string) int {
-	var json *jason.Object
-	var jsonFetchErr error
 	filesToGet := make(chan string)
 	var getFileDone sync.WaitGroup
 
@@ -173,16 +170,16 @@ func doGet(item string, files []string) int {
 	fileLists := NewLists(*fileroot)
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = conn.GetItemInfo(item)
+	json, err := conn.GetItemInfo(item)
 
 	// If not found or error, we're done
 
 	switch {
-	case jsonFetchErr == bclientapi.ErrNotFound:
+	case err == bclientapi.ErrNotFound:
 		fmt.Printf("\n Item %s was not found on server %s\n", item, *server)
 		return 1
-	case jsonFetchErr != nil:
-		fmt.Println(jsonFetchErr)
+	case err != nil:
+		fmt.Println(err)
 		return 1
 	}
 
@@ -256,9 +253,6 @@ func download(conn *bclientapi.Connection, item string, filename string, pathPre
 // doGetStub builds an empty skeleton of an item, with zero length files
 
 func doGetStub(item string) int {
-	var json *jason.Object
-	var jsonFetchErr error
-
 	// if file or dir exists in target path named after the item, give error mesg and exit
 	pathPrefix := path.Join(*fileroot, item)
 
@@ -279,15 +273,15 @@ func doGetStub(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = conn.GetItemInfo(item)
+	json, err := conn.GetItemInfo(item)
 
 	// If not found or error, we're done; otherwise, create Item Stub
 
 	switch {
-	case jsonFetchErr == bclientapi.ErrNotFound:
+	case err == bclientapi.ErrNotFound:
 		fmt.Printf("\n Item %s was not found on server %s\n", item, *server)
-	case jsonFetchErr != nil:
-		fmt.Println(jsonFetchErr)
+	case err != nil:
+		fmt.Println(err)
 		return 1
 	default:
 		MakeStubFromJSON(json, item, pathPrefix)
@@ -297,10 +291,6 @@ func doGetStub(item string) int {
 }
 
 func doHistory(item string) int {
-
-	var json *jason.Object
-	var jsonFetchErr error
-
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
 		ChunkSize: *chunksize,
@@ -308,28 +298,23 @@ func doHistory(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = conn.GetItemInfo(item)
+	json, err := conn.GetItemInfo(item)
 
 	switch {
-	case jsonFetchErr == bclientapi.ErrNotFound:
+	case err == bclientapi.ErrNotFound:
 		fmt.Printf("\n Item %s was not found on server %s\n", item, *server)
 		return 0
-	case jsonFetchErr != nil:
-		fmt.Println(jsonFetchErr)
+	case err != nil:
+		fmt.Println(err)
 		return 1
 	default:
 		PrintListFromJSON(json)
 	}
 
 	return 0
-
 }
 
 func doLs(item string) int {
-
-	var json *jason.Object
-	var jsonFetchErr error
-
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
 		ChunkSize: *chunksize,
@@ -337,13 +322,13 @@ func doLs(item string) int {
 	}
 
 	// Fetch Item Info from bclientapi
-	json, jsonFetchErr = conn.GetItemInfo(item)
+	json, err := conn.GetItemInfo(item)
 
 	switch {
-	case jsonFetchErr == bclientapi.ErrNotFound:
+	case err == bclientapi.ErrNotFound:
 		fmt.Printf("\n Item %s was not found on server %s\n", item, *server)
-	case jsonFetchErr != nil:
-		fmt.Println(jsonFetchErr)
+	case err != nil:
+		fmt.Println(err)
 		return 1
 	default:
 		PrintLsFromJSON(json, *version, *longV, *blobs, item)

--- a/cmd/bclient/main.go
+++ b/cmd/bclient/main.go
@@ -165,7 +165,14 @@ func doGet(item string, files []string) int {
 
 	// set up communication to the bendo server, and init local and remote filelists
 
-	thisItem := bclientapi.New(*server, item, *fileroot, *chunksize, *wait, *token)
+	thisItem := &bclientapi.Connection{
+		HostURL:   *server,
+		Item:      item,
+		Fileroot:  *fileroot,
+		ChunkSize: *chunksize,
+		Wait:      *wait,
+		Token:     *token,
+	}
 	fileLists := NewLists(*fileroot)
 
 	// Fetch Item Info from bclientapi
@@ -247,7 +254,14 @@ func doGetStub(item string) int {
 
 	// fetch info about this item from the bendo server
 
-	thisItem := bclientapi.New(*server, item, *fileroot, *chunksize, *wait, *token)
+	thisItem := &bclientapi.Connection{
+		HostURL:   *server,
+		Item:      item,
+		Fileroot:  *fileroot,
+		ChunkSize: *chunksize,
+		Wait:      *wait,
+		Token:     *token,
+	}
 
 	// Fetch Item Info from bclientapi
 	json, jsonFetchErr = thisItem.GetItemInfo()
@@ -272,7 +286,14 @@ func doHistory(item string) int {
 	var json *jason.Object
 	var jsonFetchErr error
 
-	thisItem := bclientapi.New(*server, item, *fileroot, *chunksize, *wait, *token)
+	thisItem := &bclientapi.Connection{
+		HostURL:   *server,
+		Item:      item,
+		Fileroot:  *fileroot,
+		ChunkSize: *chunksize,
+		Wait:      *wait,
+		Token:     *token,
+	}
 
 	// Fetch Item Info from bclientapi
 	json, jsonFetchErr = thisItem.GetItemInfo()
@@ -297,7 +318,14 @@ func doLs(item string) int {
 	var json *jason.Object
 	var jsonFetchErr error
 
-	thisItem := bclientapi.New(*server, item, *fileroot, *chunksize, *wait, *token)
+	thisItem := &bclientapi.Connection{
+		HostURL:   *server,
+		Item:      item,
+		Fileroot:  *fileroot,
+		ChunkSize: *chunksize,
+		Wait:      *wait,
+		Token:     *token,
+	}
 
 	// Fetch Item Info from bclientapi
 	json, jsonFetchErr = thisItem.GetItemInfo()

--- a/cmd/bclient/upload.go
+++ b/cmd/bclient/upload.go
@@ -27,9 +27,7 @@ func doUpload(item string, file string) int {
 
 	conn := &bclientapi.Connection{
 		HostURL:   *server,
-		Fileroot:  *fileroot,
 		ChunkSize: *chunksize,
-		Wait:      *wait,
 		Token:     *token,
 	}
 	var localfiles *FileList

--- a/cmd/bclient/upload.go
+++ b/cmd/bclient/upload.go
@@ -96,7 +96,8 @@ func doUpload(item string, file string) int {
 	}
 
 	if *wait {
-		err = conn.WaitForCommitFinish(transaction)
+		txid := path.Base(transaction)
+		err = conn.WaitTransaction(txid)
 		if err != nil {
 			fmt.Println(err)
 			return 1

--- a/cmd/bclient/upload.go
+++ b/cmd/bclient/upload.go
@@ -372,8 +372,16 @@ func UploadBlobs(conn *bclientapi.Connection, item string, todo []Action) error 
 				if *verbose {
 					fmt.Println("Uploading", t.Source)
 				}
-				err := conn.UploadFile(item, t.Source, t.MD5, t.MimeType)
+				f, err := os.Open(t.Source)
+				if err == nil {
+					remotekey := item + "-" + hex.EncodeToString(t.MD5)
+					err = conn.Upload(remotekey, f, bclientapi.FileInfo{
+						MD5:      t.MD5,
+						Mimetype: t.MimeType})
+					f.Close()
+				}
 				if err != nil {
+					fmt.Printf("Error uploading %s, %s\n", t.Source, err)
 					select {
 					case errorchan <- err:
 					default:

--- a/cmd/bclient/upload.go
+++ b/cmd/bclient/upload.go
@@ -44,7 +44,7 @@ func doUpload(item string, file string) int {
 
 	// While checksums are going, try to get remote tree
 	fmt.Println("Looking up item", item, "on remote server")
-	json, err := conn.GetItemInfo(item)
+	json, err := conn.ItemInfo(item)
 	if err == nil {
 		remotefiles = New(root)
 		remotefiles.BuildListFromJSON(json)
@@ -55,7 +55,7 @@ func doUpload(item string, file string) int {
 	// Wait for scan to finish
 	wg.Wait()
 	if err != nil {
-		// If GetItemInfo returns other error, bendo unvavailable for upload- abort!
+		// If ItemInfo returns other error, bendo unvavailable for upload- abort!
 		fmt.Println(err)
 		return 1
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -303,6 +303,10 @@ func (s *RESTServer) initCommitQueue() {
 	}
 }
 
+func (s *RESTServer) Handler() http.Handler {
+	return s.addRoutes()
+}
+
 func (s *RESTServer) addRoutes() http.Handler {
 	var routes = []struct {
 		method  string


### PR DESCRIPTION
Lots of small changes (left as individual commits) on the API between cmd/bclient and bendoapi.

* Rename `ItemAttributes` to `Connection` since it represents a connection to a bendo server
* Remove unused attributes from `Connection`
* Move some functionality from bclientapi to cmd/bclient because it was very specific to how bclient assumed files appeared on the filesystem
* Have bclientapi use a timeout when connecting to a server (this is a preventative measure)
* Make both blocking and non-blocking ways to get the status of a transaction
* Add some tests to bclientapi