### PR TITLE
Use sequence number to identify new transactions

### DIFF
--- a/server/transaction.go
+++ b/server/transaction.go
@@ -23,13 +23,13 @@ func (s *RESTServer) ListTxHandler(w http.ResponseWriter, r *http.Request, ps ht
 var (
 	listTxTemplate = template.Must(template.New("listtx").Parse(`<html>
 <h1>Transactions</h1>
-<ol>
+<ul>
 {{ range . }}
 	<li><a href="/transaction/{{ . }}">{{ . }}</a></li>
 {{ else }}
 	<li>No Transactions</li>
 {{ end }}
-</ol>
+</ul>
 </html>`))
 )
 


### PR DESCRIPTION
The existing way was to use a random number written as base 31, but this
makes confusing identifiers. This changes new transactions to use a
sequence number starting at 1 on a server restart. The existing
transactions are checked to prevent identifier re-use, so this is safe
for server restarts.