### PR TITLE
Remove /blob/ routes

### DIFF
--- a/architecture/api.md
+++ b/architecture/api.md
@@ -242,9 +242,8 @@ following forms.
 
     [“delete”, blobid]
 Purges the underlying blob from our underlying storage. blobid is either an
-integer giving the blob id, or a URL to the blob of the form /blob/:item/:blob.
-It is an error to delete a blob which is being uploaded in the current
-transaction.
+integer giving the blob id. It is an error to delete a blob which is being
+uploaded in the current transaction.
 
     [“slot”, “slot name”, blobid]
 Sets the given slot to point to the given blob id. The blob id may either be an

--- a/server/item.go
+++ b/server/item.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
@@ -43,18 +42,6 @@ type blobDB interface {
 	// Index the given item using the given id.
 	// (The item id should already be in the item structure. can that parameter be removed?)
 	IndexItem(itemid string, item *items.Item) error
-}
-
-// BlobHandler handles requests to GET /blob/:id/:bid
-func (s *RESTServer) BlobHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	id := ps.ByName("id")
-	bid, err := strconv.ParseInt(ps.ByName("bid"), 10, 0)
-	if err != nil || bid <= 0 {
-		w.WriteHeader(404)
-		fmt.Fprintln(w, err)
-		return
-	}
-	s.getblob(w, r, id, items.BlobID(bid))
 }
 
 // SlotHandler handles requests to GET /item/:id/*slot

--- a/server/routes.go
+++ b/server/routes.go
@@ -185,10 +185,6 @@ func (s *RESTServer) addRoutes() http.Handler {
 		role    Role // RoleUnknown means no API key is needed to access
 		handler httprouter.Handle
 	}{
-		// the /blob/* routes can be removed. they are functionally the
-		// same as /item/@blob/*
-		{"GET", "/blob/:id/:bid", RoleRead, s.BlobHandler},
-		{"HEAD", "/blob/:id/:bid", RoleRead, s.BlobHandler},
 		{"GET", "/item/:id/*slot", RoleUnknown, s.SlotHandler},
 		{"HEAD", "/item/:id/*slot", RoleUnknown, s.SlotHandler},
 		{"GET", "/item/:id", RoleUnknown, s.ItemHandler},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -52,8 +52,8 @@ func TestTransaction1(t *testing.T) {
 	waitTransaction(t, txpath)
 
 	checkStatus(t, "GET", "/item/"+itemid, 200)
-	checkStatus(t, "GET", "/blob/"+itemid+"/2", 404)
-	text := getbody(t, "GET", "/blob/"+itemid+"/1", 200)
+	checkStatus(t, "GET", "/item/"+itemid+"/@blob/2", 404)
+	text := getbody(t, "GET", "/item/"+itemid+"/@blob/1", 200)
 	if text != "hello world and hello sun" {
 		t.Fatalf("Received %#v, expected %#v", text, "hello world and hello sun")
 	}


### PR DESCRIPTION
These routes were unused and undocumented. The same functionality is
also implemented in the /item/:id/@blob/:bid routes, which are
documented.