### PR TITLE
Check for no version list in handler

### DIFF
--- a/server/item.go
+++ b/server/item.go
@@ -410,8 +410,11 @@ func (s *RESTServer) ItemHandler(w http.ResponseWriter, r *http.Request, ps http
 		fmt.Fprintln(w, err.Error())
 		return
 	}
-	vid := item.Versions[len(item.Versions)-1].ID
-	w.Header().Set("ETag", fmt.Sprintf(`"%d"`, vid))
+	// sometimes when there are storage errors no Version list gets saved to tape.
+	if len(item.Versions) > 0 {
+		vid := item.Versions[len(item.Versions)-1].ID
+		w.Header().Set("ETag", fmt.Sprintf(`"%d"`, vid))
+	}
 	writeHTMLorJSON(w, r, itemTemplate, item)
 }
 


### PR DESCRIPTION
Sometimes a transaction will have storage errors, so no version list
gets saved to tape. The Handler needs to deal with this so we can
continue uploading files and eventually save a new version.