### PR TITLE
Use in-memory database for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bendo_storage/*
 bendo_cache/*
 config.local
 .vscode
+.DS_Store

--- a/bclientapi/chunkfile_test.go
+++ b/bclientapi/chunkfile_test.go
@@ -52,7 +52,7 @@ func TestUpload(t *testing.T) {
 }
 
 func NewLocalBendoServer() (*ErrorServer, *httptest.Server) {
-	db, _ := server.NewQlCache("memory--server")
+	db, _ := server.NewQlCache("mem--server")
 	bendo := &server.RESTServer{
 		Validator:      server.NobodyValidator{},
 		Items:          items.NewWithCache(store.NewMemory(), items.NewMemoryCache()),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -333,7 +333,7 @@ func waitTransaction(t *testing.T, txpath string) {
 var testServer *httptest.Server
 
 func init() {
-	db, _ := NewQlCache("memory--server")
+	db, _ := NewQlCache("mem--server")
 	server := &RESTServer{
 		Validator:      NobodyValidator{},
 		Items:          items.NewWithCache(store.NewMemory(), items.NewMemoryCache()),


### PR DESCRIPTION
This fixes a typo. in memory database have a prefix of `mem--` not
`memory--`