### PR TITLE
Decode slots paths using the database

### DIFF
--- a/cmd/bendo/main.go
+++ b/cmd/bendo/main.go
@@ -180,6 +180,7 @@ func setupDatabase(config *bendoConfig, s *server.RESTServer) {
 	var db interface {
 		server.FixityDB
 		items.ItemCache
+		server.BlobDB
 	}
 	var err error
 	if config.Mysql != "" {
@@ -201,6 +202,7 @@ func setupDatabase(config *bendoConfig, s *server.RESTServer) {
 	if db == nil || err != nil {
 		log.Fatalln("problem setting up database")
 	}
+	s.BlobDB = db
 	s.FixityDatabase = db
 	s.Items.SetCache(db)
 }

--- a/server/db_mysql.go
+++ b/server/db_mysql.go
@@ -26,7 +26,7 @@ type MsqlCache struct {
 
 var _ items.ItemCache = &MsqlCache{}
 var _ FixityDB = &MsqlCache{}
-var _ blobDB = &MsqlCache{}
+var _ BlobDB = &MsqlCache{}
 
 // List of migrations to perform. Add new ones to the end.
 // DO NOT change the order of items already in this list.

--- a/server/db_ql.go
+++ b/server/db_ql.go
@@ -27,7 +27,7 @@ type QlCache struct {
 
 var _ items.ItemCache = &QlCache{}
 var _ FixityDB = &QlCache{}
-var _ blobDB = &QlCache{}
+var _ BlobDB = &QlCache{}
 
 // List of migrations to perform. Add new ones to the end.
 // DO NOT change the order of items already in this list.

--- a/server/routes.go
+++ b/server/routes.go
@@ -63,6 +63,11 @@ type RESTServer struct {
 	// Cache keeps smallish blobs retreived from tape.
 	Cache blobcache.T
 
+	// BlobDB holds the item/version/slot/blob information in a structured way
+	// so we can query it without needing to read and parse the JSON structures
+	// describing items.
+	BlobDB BlobDB
+
 	// Fixity stores the records tracking past and future fixity checks.
 	FixityDatabase FixityDB
 	DisableFixity  bool

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -340,6 +340,7 @@ func init() {
 		TxStore:        transaction.New(store.NewMemory()),
 		FileStore:      fragment.New(store.NewMemory()),
 		Cache:          blobcache.NewLRU(store.NewMemory(), 400),
+		BlobDB:         db,
 		FixityDatabase: db,
 		useTape:        true,
 	}

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -161,6 +161,7 @@ func (s *RESTServer) transactionWorker(queue <-chan string) {
 				}
 			}
 			tx.Commit(*s.Items, s.FileStore, s.Cache)
+			s.IndexItem(tx.ItemID)
 		}
 	out:
 		duration := time.Now().Sub(start)


### PR DESCRIPTION
This patch moves the decoding into the server package where the database
is used to figure out the blob identifier directly rather than realizing
the entire item in memory and then walking the blob and version lists.
Items that have not been indexed into the database will be indexed upon
being accessed.

It was slightly odd that these server paths were defined in the item
package. At some point it would be good to completely remove the "Item
Cache" from the items package. It was a bit of a hack to get everything
working in the first place.